### PR TITLE
Add list of normalized artist names

### DIFF
--- a/artist_name.py
+++ b/artist_name.py
@@ -1,0 +1,14 @@
+import json
+
+
+class NormalizedArtistName(object):
+    def __init__(self):
+        self._normalized_names = {}
+        with open('normalized_artist_names.json', 'r') as fh:
+            names = json.load(fh)
+        for canonical_name, alternate_names in names.items():
+            for alternate_name in alternate_names:
+                self._normalized_names[alternate_name] = canonical_name
+
+    def get_canonical_artist_name(self, artist_name: str) -> str:
+        return self._normalized_names.get(artist_name, artist_name)

--- a/normalized_artist_names.json
+++ b/normalized_artist_names.json
@@ -1,0 +1,4438 @@
+{
+    "'Little' Louie Vega": [
+        "Little Louis Vega"
+    ],
+    "*NSYNC": [
+        "N-Sync"
+    ],
+    "16 Bit": [
+        "16 BIT",
+        "16bit"
+    ],
+    "16th Element": [
+        "16th Elements"
+    ],
+    "2 Phat C**ts": [
+        "2 Phat C"
+    ],
+    "2000 And One": [
+        "2000 and One"
+    ],
+    "2000 and One & DJ Madskillz": [
+        "2000 and One And DJ Madskills"
+    ],
+    "2000F & J Kamata": [
+        "2000F And Kamata",
+        "2000f & Jkamata"
+    ],
+    "20:20 Soundsystem": [
+        "2020 Soundystem"
+    ],
+    "A Child's Garden Of Grass": [
+        "A Childs Garden Of Grass",
+        "A Childs Gareden Of Grass"
+    ],
+    "A Guy Called Gerald": [
+        "Guy Called Gerald"
+    ],
+    "A Small Phatt One": [
+        "A Small Phat One"
+    ],
+    "A Split Second": [
+        "Split Second"
+    ],
+    "A Tribe Called Quest": [
+        "Tribe Called Quest"
+    ],
+    "A-Trak & Laidback Luke": [
+        "A Trak & Laidback Luke",
+        "ATrack & Laidback Luke"
+    ],
+    "AC/DC": [
+        "AC DC",
+        "ACDC"
+    ],
+    "AN-2": [
+        "An-2"
+    ],
+    "AN21 & Max Vangelli": [
+        "AN21 & Max Vangeli"
+    ],
+    "Aardvark": [
+        "Aardvarck"
+    ],
+    "Aaron Carl": [
+        "Aaron-Carl",
+        "Arron Carl"
+    ],
+    "Aaron La Crate": [
+        "Aaron Lacrate"
+    ],
+    "Aaron Ochoa": [
+        "Aaron Ochaa"
+    ],
+    "Adam Beyer": [
+        "A. Beyer"
+    ],
+    "Adam K & Soha": [
+        "Adam K And Soha"
+    ],
+    "Afrika Bambattaa & Soul Sonic Force": [
+        "Afrika Bambaataa & Soulsonic Force",
+        "Afrika Bambaataa And The Soul Sonice Force",
+        "Afrika Bambatta & The Soul Sonic Force"
+    ],
+    "Afrojack & Steve Aoki": [
+        "Afrojack & Steveaoki"
+    ],
+    "Afrojack Feat. Eva Simons": [
+        "+ Afrojack Feat. Eva Simons"
+    ],
+    "Age Of Love": [
+        "Age of Love"
+    ],
+    "Agnelli & Nelson": [
+        "Angelli & Nelson"
+    ],
+    "Air Frog": [
+        "Airfrog"
+    ],
+    "Air Liquid": [
+        "Air Liquide"
+    ],
+    "Ajello": [
+        "AJELLO"
+    ],
+    "Akabu": [
+        "AKABU"
+    ],
+    "Alex Gopher & Etienne De Cr\u00e9cy": [
+        "Alex Gopher & Etienne De Crecy"
+    ],
+    "Alex Kenji, Starkillers & Nadia Ali": [
+        "Alex Kenji, Star Killers & Nadia Ali"
+    ],
+    "Alexander Robotnik": [
+        "Alexander Robotnick"
+    ],
+    "Alexkid": [
+        "Alex Kid",
+        "Alex Kidd"
+    ],
+    "Alexkid & Chloe": [
+        "Alexkid And Chloe"
+    ],
+    "Alison Limerick": [
+        "Alison Limmerick"
+    ],
+    "Alka Rex": [
+        "Alka_Rex"
+    ],
+    "All-Star Madness": [
+        "All Star Madness"
+    ],
+    "Aly\u2010Us": [
+        "Aly Us",
+        "Aly-Us"
+    ],
+    "Amando": [
+        "Armando"
+    ],
+    "Amine Edge & Dance": [
+        "Amine Edge & DANCE"
+    ],
+    "Amoeba Assassin": [
+        "Amoeba Assasin"
+    ],
+    "Amtrac": [
+        "AMTRAC"
+    ],
+    "Analogue People In A Digital World": [
+        "Analog People In A Digital World"
+    ],
+    "Andrea Olivia": [
+        "Andrea Oliva"
+    ],
+    "Andrew McLauchlan": [
+        "Andrew McLaughlan"
+    ],
+    "Andr\u00e9 Kronert": [
+        "Andre Kronert"
+    ],
+    "Andr\u00e9 Lodemann": [
+        "Andre Lodemann"
+    ],
+    "Andy Chatterley": [
+        "Andy Chatterly"
+    ],
+    "Angel Morales": [
+        "Angel Moraes"
+    ],
+    "Animals At Night": [
+        "Animals By Night"
+    ],
+    "Annabella Lwin": [
+        "Anabella Lwin"
+    ],
+    "Annette Taylor": [
+        "Arnette Taylor"
+    ],
+    "Antarctica": [
+        "Antartica"
+    ],
+    "Antonine Claraman": [
+        "Antoine Clamaran",
+        "Antoine Claraman"
+    ],
+    "Aphrohead": [
+        "Afrohead",
+        "Aprohead"
+    ],
+    "Aquasky vs Masterblaster": [
+        "Aquasky vs Master Blaster"
+    ],
+    "Archie Shepp": [
+        "Archie Shep"
+    ],
+    "Armand Van Helden": [
+        "Armand Van Heldan"
+    ],
+    "Armin Van Buuren": [
+        "Armin van Buuren"
+    ],
+    "Arnold Jarvis & Kerri Chandler": [
+        "Arnold Jarvis & Keri Chandler"
+    ],
+    "Art Crime": [
+        "Artcrime"
+    ],
+    "Artbat": [
+        "ARTBAT"
+    ],
+    "Artist Unknown": [
+        "Artist Uknown"
+    ],
+    "Asha D": [
+        "Ashah",
+        "Aswad"
+    ],
+    "At Jazz": [
+        "Atjazz"
+    ],
+    "Attaque": [
+        "Ataque"
+    ],
+    "Audio Bootyz": [
+        "Audio Bootys"
+    ],
+    "Audio Bullies": [
+        "Audio Bully's",
+        "Audio Bullys"
+    ],
+    "Audio Sound Project": [
+        "Audio Soul Project"
+    ],
+    "Autokratz": [
+        "AutoKratz"
+    ],
+    "Aux 88": [
+        "AUX 88"
+    ],
+    "Avicii": [
+        "''Avicii",
+        "Avicii"
+    ],
+    "Avicii & Lenny Kravitz": [
+        "Avicii vs Lenny Kravitz"
+    ],
+    "Aybee": [
+        "AYBEE"
+    ],
+    "B-Tribe": [
+        "B Tribe"
+    ],
+    "BK & Alex Kidd": [
+        "Bk & Alex Kidd"
+    ],
+    "BK & Paul Masterson": [
+        "Bk & Paul Masterson"
+    ],
+    "Bad Marsh & Shri": [
+        "Badmarsh & Shri"
+    ],
+    "Bag Raiders": [
+        "Bagraiders"
+    ],
+    "Banco De Gaia": [
+        "Bango De Gaia"
+    ],
+    "Barbara Tucker": [
+        "Babara Tucker"
+    ],
+    "Basement Jaxx": [
+        "Bassment Jaxx"
+    ],
+    "Bass Bin Twins": [
+        "Bassbin Twins",
+        "Bassbintwins"
+    ],
+    "Bass Toy": [
+        "Basstoy"
+    ],
+    "Bastian Heerhorst": [
+        "Bastian Heerhosrt"
+    ],
+    "Beat Box": [
+        "Beatbox"
+    ],
+    "Bebel Gilberto": [
+        "Bebel Giberto"
+    ],
+    "Ben Long": [
+        "Den Long"
+    ],
+    "Ben Simms": [
+        "Ben Sims"
+    ],
+    "Ben Sims / Phil Vernol / Rob Jarvis": [
+        "Ben Sims/Phil Vernol/Rob Jarvis"
+    ],
+    "Benjamin Damage & Doc Daneeka": [
+        "Benjamin Damage & Doc Daneeca"
+    ],
+    "Benny Benassi": [
+        "Ben Benassi"
+    ],
+    "Benny Page & Zero G": [
+        "Bennypage & Zero G"
+    ],
+    "Bently Rhythm Ace": [
+        "Bentley's Rhythm Ace"
+    ],
+    "Beyonc\u00e9": [
+        "Beyonce"
+    ],
+    "Big Daddy Kane": [
+        "Big Daddy Cane"
+    ],
+    "Bill Payer & Fat Hippy": [
+        "Bill Payer And Fat Hippy",
+        "Billy Payer & Fat Hippy"
+    ],
+    "Billie Ray Martin": [
+        "Billy Ray Martin"
+    ],
+    "Billy D'Alessandro": [
+        "Billy Alessandro"
+    ],
+    "Billy The Klit & Dani L Mebius": [
+        "Billy The Kilt & Dani L Mebius"
+    ],
+    "Bionic Bump Band": [
+        "Boinic Bump Band"
+    ],
+    "Biz Markie": [
+        "Biz Mackie"
+    ],
+    "Bizarre Inc.": [
+        "Bizarre Inc"
+    ],
+    "Black Box": [
+        "Blackbox"
+    ],
+    "Black Ghosts": [
+        "Black Ghost",
+        "The Black Ghosts"
+    ],
+    "Black Sheep": [
+        "Blacksheep"
+    ],
+    "Black Strobe": [
+        "Blackstrobe"
+    ],
+    "Blackalicious": [
+        "Blackicious"
+    ],
+    "Blank & Jones": [
+        "Blanks & Jones"
+    ],
+    "Blokhe4d": [
+        "Blockhead"
+    ],
+    "Blu Cantrell": [
+        "Blue Cantrell"
+    ],
+    "Bob Sinclar": [
+        "Bob Sinclar."
+    ],
+    "Bobby D'Ambrosio": [
+        "Bobby D'ambrosio"
+    ],
+    "Body Rox": [
+        "Bodyrox"
+    ],
+    "Bodyshock": [
+        "Body Shock"
+    ],
+    "Bodzin & Huntemann": [
+        "Bodzin & Hunteman"
+    ],
+    "Bombdogs": [
+        "Bomb Dogs"
+    ],
+    "Bone Crusher": [
+        "Bonecrusher"
+    ],
+    "Booka Shade": [
+        "Bookashade"
+    ],
+    "Boris Dlugosch": [
+        "Boris Dlugosh"
+    ],
+    "Bostich": [
+        "Bostick"
+    ],
+    "Boy 8-Bit": [
+        "Boy 8 Bit"
+    ],
+    "Boys Noize": [
+        "Boys Nozie",
+        "Boysnoize"
+    ],
+    "Boys Noize & Erol Alkan": [
+        "Boys Noize & Erol Alkon"
+    ],
+    "BrEaCh": [
+        "Breach"
+    ],
+    "BrEaCh vs Ron Costa": [
+        "Breach vs Ron Costa"
+    ],
+    "Brain Bug": [
+        "Brainbug"
+    ],
+    "Brancaccio & Asher": [
+        "Brancaccio & Aisher",
+        "Brancaccio And Aisher",
+        "Brancaccio And Asher",
+        "Brancacio & Aisher",
+        "Brancchio & Asher"
+    ],
+    "Brand Nubian": [
+        "Brand Nubain"
+    ],
+    "Brett Johnson": [
+        "Brett Johson"
+    ],
+    "Brian Zentz": [
+        "Bryan Zentz"
+    ],
+    "Brothers": [
+        "The Brothers"
+    ],
+    "Bsod": [
+        "BSOD"
+    ],
+    "Bubba Sparxx": [
+        "Bubba Sparx"
+    ],
+    "Bumblebee Unlimited": [
+        "BumbleBee Unlimited"
+    ],
+    "Bushwacka!": [
+        "Bushwacka"
+    ],
+    "Busta Rhymes": [
+        "Bustah Rhymes"
+    ],
+    "Buy Now!": [
+        "Buy Now"
+    ],
+    "Byron Stingley": [
+        "Byron Stingily",
+        "Byron Stingley",
+        "Byron Stingly",
+        "Byron Strinly"
+    ],
+    "C'hantal": [
+        "Chantal",
+        "Chantel"
+    ],
+    "CZR & Ito": [
+        "CZR & ITO"
+    ],
+    "Calyx & Teebee": [
+        "Calyx & TeeBee"
+    ],
+    "Camisra": [
+        "Carisma"
+    ],
+    "Candi Staton": [
+        "Candi Stantion",
+        "Candy Staton"
+    ],
+    "Candida": [
+        "Candido"
+    ],
+    "Cappella": [
+        "Capella"
+    ],
+    "Carl B.": [
+        "Carl B"
+    ],
+    "Carl Finlow": [
+        "Carl A. Finlow"
+    ],
+    "Carl Lekebusch": [
+        "Cari Lekebusch",
+        "Cari Lekebuscha"
+    ],
+    "Carleen Anderson": [
+        "Carlene Anderson"
+    ],
+    "Carlos Sanchez": [
+        "Carlo Sanchez"
+    ],
+    "Carolyn Harding": [
+        "Caroline Harding"
+    ],
+    "Cass & Slide": [
+        "Cass And Slide"
+    ],
+    "Catz 'N Dogz": [
+        "Catz N' Dogz"
+    ],
+    "CeCe Peniston": [
+        "Ce Ce Peniston"
+    ],
+    "CeCe Rogers": [
+        "Ce Ce Rogers"
+    ],
+    "Cedric Gervais": [
+        "Cerdric Gervais"
+    ],
+    "Centurions": [
+        "Centurians"
+    ],
+    "Chabel & Bonicci": [
+        "Chable & Bonnici",
+        "Chable And Bonicci"
+    ],
+    "Chanelle": [
+        "Channelle"
+    ],
+    "Chase & Status": [
+        "''Chase & Status",
+        "Chase And Status"
+    ],
+    "Chelonis R. Jones": [
+        "Chelonis R Jones",
+        "Chelonis R.Jones"
+    ],
+    "Chiapet": [
+        "Chaipet"
+    ],
+    "Chlo\u00e9": [
+        "Chloe"
+    ],
+    "Choo-Choo Project": [
+        "Choo Choo Project"
+    ],
+    "Chord Symbols": [
+        "Choro Symbols"
+    ],
+    "Chris & James": [
+        "Chris And James"
+    ],
+    "Chris Cuevos": [
+        "Chris Cuevas"
+    ],
+    "Chris Liebing": [
+        "Chris Liebling"
+    ],
+    "Christian L\u00f6ffler": [
+        "Christian Loeffler"
+    ],
+    "Christian Smith & E.B.E.": [
+        "Christian Smith & EBE"
+    ],
+    "Christian Smith & John Selway": [
+        "Christian Smith + John Selway",
+        "Christian Smith And John Selway"
+    ],
+    "Christian Smith vs Jean-Phillipe Aviance": [
+        "Christian Smith vs Jean Phillipe Aviance"
+    ],
+    "Christina Aguilera": [
+        "Christine Aguilera"
+    ],
+    "Christopher Lawrence": [
+        "Christopher Laurence"
+    ],
+    "Chus & Ceballos": [
+        "Chus And Ceballos"
+    ],
+    "Chymera": [
+        "Chimera"
+    ],
+    "Ch\u00c3\u00a2teau Flight": [
+        "Chateau Flight",
+        "Ch\u00e2teau Flight"
+    ],
+    "Circus Nights": [
+        "Circus Night"
+    ],
+    "Citizen": [
+        "Citizenn"
+    ],
+    "Clap! Clap!": [
+        "Clap!Clap!"
+    ],
+    "Clapz II Dogz": [
+        "Clapz Ii Dogz"
+    ],
+    "Cleptomaniacs": [
+        "Clepto-Maniacs"
+    ],
+    "Cloak & Dagger": [
+        "Cloak And Dagger"
+    ],
+    "Coco Steel & Love Bomb": [
+        "Coco Steel & Lovebomb"
+    ],
+    "Coldcut": [
+        "ColdCut"
+    ],
+    "Coldplay vs Swedish House Mafia": [
+        "Coldplay Vs Swedish House Mafia"
+    ],
+    "Colin Barratt": [
+        "Colin Barrat"
+    ],
+    "Colonel Abrams": [
+        "Colonol Abrams"
+    ],
+    "Condor II": [
+        "Condor 11"
+    ],
+    "Corrina Joseph": [
+        "Corina Joseph"
+    ],
+    "Cowboy Rhythmbox": [
+        "Cowboy Rythmbox"
+    ],
+    "Cox & Wink": [
+        "Cox And Wink"
+    ],
+    "Craig Loftis": [
+        "Craig S. Loftis"
+    ],
+    "Crescendo": [
+        "Cresendo"
+    ],
+    "Critical Phase": [
+        "Critial Phase"
+    ],
+    "Crustacian": [
+        "Crustation"
+    ],
+    "Curses!": [
+        "Curses"
+    ],
+    "Cut & Paste": [
+        "Cut And Paste"
+    ],
+    "D'Kawa": [
+        "D Kawa"
+    ],
+    "D'Lacey": [
+        "D'Lacy",
+        "De Lacy",
+        "De'Lacy",
+        "Delacy"
+    ],
+    "D'Menace": [
+        "D'Menance"
+    ],
+    "D-Malice": [
+        "D Malice"
+    ],
+    "D-Note": [
+        "D Note"
+    ],
+    "D-Train": [
+        "D\u2010Train"
+    ],
+    "D. Kay": [
+        "D Kay"
+    ],
+    "D. Ramirez": [
+        "D.Ramirez"
+    ],
+    "D. Ramirez & Mark Knight": [
+        "D Ramirez & Mark Knight",
+        "D.Ramirez & Mark Knight",
+        "D.Ramirez And Mark Knight"
+    ],
+    "D:Ream": [
+        "D'Ream",
+        "D.Ream",
+        "D:ream",
+        "Dream"
+    ],
+    "DJ Assassins": [
+        "DJ Assassin"
+    ],
+    "DJ Dan pres. Needle Damage": [
+        "DJ Dan Pres. Needle Damage"
+    ],
+    "DJ E-Clyps": [
+        "DJ Eclipse"
+    ],
+    "DJ Garth & ETI": [
+        "DJ Garth & E.T.I."
+    ],
+    "DJ Gary": [
+        "DJ Garry"
+    ],
+    "DJ Go Go": [
+        "DJ Gogo"
+    ],
+    "DJ Hansz": [
+        "DJ Hanz"
+    ],
+    "DJ Icee": [
+        "DJ Icey"
+    ],
+    "DJ Manny Groove": [
+        "DJ Many Groove"
+    ],
+    "DJ Mehdi": [
+        "DJ Medhi"
+    ],
+    "DJ Misjah & DJ Tim": [
+        "DJ Misjah & Mr. Tim"
+    ],
+    "DJ Misjah & DJ Tim vs Underworld": [
+        "DJ Misjah & DJ Tim vs. Underworld"
+    ],
+    "DJ Phoenix": [
+        "DJ Pheonix"
+    ],
+    "DJ Pippi & David Penn": [
+        "DJ Pippi And David Penn"
+    ],
+    "DJ Remy": [
+        "D.J. Remy"
+    ],
+    "DJ Sakin & Friends": [
+        "DJ Sakin & Friend"
+    ],
+    "DJ Scot Project": [
+        "DJ Scott Project"
+    ],
+    "DJ Shufflemaster": [
+        "DJ ShuffleMaster"
+    ],
+    "DJ Tamiel": [
+        "DJ Tameil"
+    ],
+    "DJ Technics": [
+        "DJ Technic"
+    ],
+    "DJ Touche & Pepe": [
+        "DJ Touch\u00e9 vs Pepe"
+    ],
+    "DJ Touch\u00e9": [
+        "DJ Touche"
+    ],
+    "Daft Punk": [
+        "FDaft Punk"
+    ],
+    "Daley Padley & Chris Special": [
+        "Daley Padley & Chris Specia"
+    ],
+    "Damian Schwartz": [
+        "Damian Schwarz",
+        "Dami\u00e1n Schwartz"
+    ],
+    "Daniel Dixon": [
+        "Danell Dixon"
+    ],
+    "Danielle Papini": [
+        "Daniel Papini",
+        "Daniele Papini"
+    ],
+    "Danny Byrd": [
+        "Danny Bryrd"
+    ],
+    "Danny Tenaglia": [
+        "Danny Teneglia",
+        "Danny Tengalia"
+    ],
+    "Dave & Ansel Collins": [
+        "Dave & Ansil Collins"
+    ],
+    "Dave Clarke": [
+        "Dave Clark"
+    ],
+    "Dave Clarke Pres. Red 2": [
+        "Dave Clarke Pres. Red 1"
+    ],
+    "Dave Robertson": [
+        "Dave Roberstson"
+    ],
+    "Dave Robertson & Jon Gurd": [
+        "Dave Roberts & Jon Gurd"
+    ],
+    "David Alvarado": [
+        "David Alvorado"
+    ],
+    "David Guetta": [
+        "Dave Guetta"
+    ],
+    "David Holmes": [
+        "Dave Holmes"
+    ],
+    "David Morales": [
+        "David Morles"
+    ],
+    "David Morales presents The Face": [
+        "David Morales Presents The Face"
+    ],
+    "Davide Squillacie": [
+        "Davide Squillace"
+    ],
+    "Deadmau5": [
+        "Deadau5"
+    ],
+    "Deadmau5 & Wolfgang Gartner": [
+        "Deadmau5 And Wolfgang Gartner"
+    ],
+    "Deadmau5 vs Jelo": [
+        "Deadmau5 V Jelo"
+    ],
+    "Deborah Cox": [
+        "Debora Cox",
+        "Debra Cox"
+    ],
+    "Deee-Lite": [
+        "Deee Lite"
+    ],
+    "Deep Dimension": [
+        "Deep_Dimension"
+    ],
+    "Deepgroove & Jamie Anderson": [
+        "Deepgroove And Jamie Anderson"
+    ],
+    "Deetron": [
+        "Deetron The"
+    ],
+    "Deetron & DJ Bone": [
+        "Deetron And DJ Bone"
+    ],
+    "Delerium": [
+        "Delirium"
+    ],
+    "Delgardo": [
+        "Del Gado"
+    ],
+    "Delicious Inc": [
+        "Delicious Ink"
+    ],
+    "Delirium feat. Sarah McLachlan": [
+        "Delerium Feat. Sarah Mclachlan"
+    ],
+    "Delon & Dalcan": [
+        "Delon And Dalcun"
+    ],
+    "Dennis Sulta": [
+        "Denis Sulta"
+    ],
+    "Der Dritte Raum": [
+        "Der Dritte Ruam"
+    ],
+    "Derelict": [
+        "DeRelict"
+    ],
+    "Derrick Carter": [
+        "Derrick L Carter"
+    ],
+    "Detroit Grand Pubahs": [
+        "Detroit Grand Pu Bahs"
+    ],
+    "Detroit Swindle": [
+        "Detriot Swindle"
+    ],
+    "Devilfish": [
+        "Devil Fish"
+    ],
+    "Dex & Jonesy": [
+        "Dex & Jonesey"
+    ],
+    "Diamond Ford": [
+        "Riamond Ford"
+    ],
+    "Dilemma": [
+        "Dilema"
+    ],
+    "Dillinja": [
+        "Dilinja"
+    ],
+    "Dimitri & Jaimy": [
+        "Dimitry & Jaimy"
+    ],
+    "Dimitri Vegas & Like Mike": [
+        "Dimitry Vegas & Like Mike"
+    ],
+    "Dirt Crew": [
+        "Dirtcrew"
+    ],
+    "Dirty Supercar": [
+        "Dirty Super Car"
+    ],
+    "Dirty White Boys": [
+        "Dirty White Boy"
+    ],
+    "Disco-Tex": [
+        "Disco Tex"
+    ],
+    "Discocaine": [
+        "Discoaine"
+    ],
+    "Divini & Warning": [
+        "Divini And Warning"
+    ],
+    "Dizzee Rascal": [
+        "Dizee Rascal",
+        "Dizze Rascal",
+        "Dizzie Rascal"
+    ],
+    "Dolls Head": [
+        "Dollshead"
+    ],
+    "Doneao": [
+        "Doeneo",
+        "Donae'o"
+    ],
+    "Donna Allen": [
+        "Donna Hallan"
+    ],
+    "Donna Summer": [
+        "Donna Sumer"
+    ],
+    "Dons": [
+        "DONS"
+    ],
+    "Dope Sumgglaz": [
+        "Dope Smugglaz",
+        "Dope Smugglerz"
+    ],
+    "Double Dee & Steinski": [
+        "Double D & Steinski"
+    ],
+    "Doug Willis": [
+        "Dobg Wills"
+    ],
+    "Dr. Dre": [
+        "Dr Dre"
+    ],
+    "Dr. Exciya": [
+        "Drexciya"
+    ],
+    "Dr. Kucho!": [
+        "Dr. Kucho"
+    ],
+    "Dr. Kucho! & Gregor Salto": [
+        "Dr. Kucho & Gregor Salto"
+    ],
+    "Dr. Octagon": [
+        "DR Octagon"
+    ],
+    "Drax & Gooding": [
+        "Drax And Gooding"
+    ],
+    "Drizabone": [
+        "Driza Bone"
+    ],
+    "Drumattic Twins": [
+        "Drummatic Twins"
+    ],
+    "Drumcode": [
+        "Drum Code"
+    ],
+    "Drumsound & Simon 'Bassline' Smith": [
+        "Drumsound & Simon Bassline Smith"
+    ],
+    "Duck Sauce": [
+        "Duck Aauce"
+    ],
+    "Durango-95": [
+        "Duango 95",
+        "Durango 95"
+    ],
+    "Dusty Kid": [
+        "Dusty Kids"
+    ],
+    "Dutch Masters": [
+        "Dutch Master"
+    ],
+    "Dyad 10": [
+        "DYAD10"
+    ],
+    "Dynarec": [
+        "DynArec"
+    ],
+    "E'Voke": [
+        "E'voke",
+        "Evoke"
+    ],
+    "E-Craig": [
+        "E. Craig"
+    ],
+    "E-Dancer": [
+        "E Dancer"
+    ],
+    "E.P.M.D.": [
+        "EPMD"
+    ],
+    "Earth, Wind & Fire": [
+        "Earth Wind And Fire"
+    ],
+    "Eastcolours": [
+        "Eastcolors"
+    ],
+    "Easy Rider": [
+        "Easy Riders"
+    ],
+    "Ecstasy": [
+        "Ecstacy"
+    ],
+    "Ed Rush & Optical": [
+        "Ed Rush And Optical"
+    ],
+    "Eddie Amadour": [
+        "Eddie Amador"
+    ],
+    "EeeZee Posse": [
+        "Ezee Posse"
+    ],
+    "Ege Ban Yasi": [
+        "Ege Bam Yasi"
+    ],
+    "Egg": [
+        "The Egg"
+    ],
+    "Egyption Lover": [
+        "Egyptin Lover"
+    ],
+    "Einzelkind & Robin Schulz": [
+        "Einzelkind & Robin Scholz"
+    ],
+    "Electro Luv": [
+        "Lectroluv"
+    ],
+    "Electronauts": [
+        "Elctronauts"
+    ],
+    "Elektra": [
+        "Electra"
+    ],
+    "Elektrochemie": [
+        "Electrochemmie"
+    ],
+    "Elektrons": [
+        "Elektons"
+    ],
+    "Elio Riso & NiLO.R vs. GruuvElements": [
+        "Elio Riso & NiLO.R vs GruuvElements"
+    ],
+    "Emmanuel Top": [
+        "Emanuel Top"
+    ],
+    "Emperor's New Clothes": [
+        "Emporer's New Clothes"
+    ],
+    "En-Motion": [
+        "En Motion"
+    ],
+    "Ennio Morricone": [
+        "Ennio Moricone"
+    ],
+    "Enrico Sangiuliano": [
+        "Enrico Sagiuliano"
+    ],
+    "Eprom": [
+        "EPROM"
+    ],
+    "Equiknoxx": [
+        "Equinox"
+    ],
+    "Eric B. & Rakim": [
+        "Eric B & Rakim",
+        "Eric B And Rakim"
+    ],
+    "Eric Prydz": [
+        "''Eric Prydz",
+        "Eric Pridz"
+    ],
+    "Eric Seno": [
+        "Eric Sneo"
+    ],
+    "Erick": [
+        "Ericke"
+    ],
+    "Erick Morillo": [
+        "Eric Morillo",
+        "Rrick Morillo"
+    ],
+    "Erick Morillo, Harry Romero & Jose Nunez": [
+        "Erick Morillo, Harry Romero And Jose Nunez",
+        "Erick Morillo, Harry Romero, Jose Nunez"
+    ],
+    "Ernesto & Bastian": [
+        "Ernesto Vs. Bastian",
+        "Ernesto vs Bastian"
+    ],
+    "Ernesto Ferreyra": [
+        "Erenesto Ferreyra"
+    ],
+    "Erol Alkan": [
+        "'Erol Alkan'''"
+    ],
+    "Erol Alkan & Boys Noize": [
+        "Erol Alkan & Boysnoize"
+    ],
+    "Evol Intent": [
+        "+ Evol Intent"
+    ],
+    "Evol Waves": [
+        "Evol Wavez"
+    ],
+    "Excerpts From Vanilla Sky": [
+        "Excepts From Vinilla Sky"
+    ],
+    "FD.I.M. & Tai": [
+        "D.I.M. & TAI"
+    ],
+    "Fake Blood": [
+        "Fakeblood"
+    ],
+    "Farley & Heller": [
+        "Farley And Heller"
+    ],
+    "Farley 'Jackmaster' Funk": [
+        "Farley Jackmaster Funk"
+    ],
+    "Fatboy Slim": [
+        "Fat Boy Slim"
+    ],
+    "Fatboy Slim & Riva Starr": [
+        "Fatboy Slim And Riva Starr"
+    ],
+    "Fatheads": [
+        "Fat Heads"
+    ],
+    "Faze Miyaki": [
+        "Faze Miyake"
+    ],
+    "Feed Me!": [
+        "Feed Me"
+    ],
+    "Felipe & Nicholas Bacher": [
+        "Filipe & Nicholas Bacher"
+    ],
+    "Felix Da Housecat": [
+        "Felix Da House Cat",
+        "Felix Da Housekatt"
+    ],
+    "Ferrer & Sydenham Inc.": [
+        "Ferrer & Sydenham Inc"
+    ],
+    "Fibre Optix": [
+        "Fibre Optics"
+    ],
+    "Fice & Ice": [
+        "Fire And Ice"
+    ],
+    "Filo & Peri": [
+        "Filo & Perry"
+    ],
+    "Fine Young Cannibals": [
+        "Fine Young Canibals"
+    ],
+    "Fingerprint": [
+        "Finger Print"
+    ],
+    "Fingers Inc.": [
+        "Fingers Inc"
+    ],
+    "Finitribe": [
+        "Fini Tribe"
+    ],
+    "Fischerspooner": [
+        "Fisherspooner"
+    ],
+    "Fisher": [
+        "FISHER"
+    ],
+    "Fixmer & McCarthy": [
+        "Fixmer / McCarthy",
+        "Fixmer And MC Carthy"
+    ],
+    "Floorjam": [
+        "Floogjam",
+        "Floor Jam"
+    ],
+    "Florence & The Machine": [
+        "Florence + The Machine",
+        "Florence And The Machine"
+    ],
+    "Flux Pavilion": [
+        "Flux Pavillion"
+    ],
+    "Flux Pavilion & SKism": [
+        "Flux Pavillion & SKism"
+    ],
+    "Foremost Poets": [
+        "Fore Most Poets"
+    ],
+    "Format:B": [
+        "Format B"
+    ],
+    "Franco Moiraghi": [
+        "Franck O'moiraghi"
+    ],
+    "Francois Dubois": [
+        "Francois Dubious"
+    ],
+    "Frankie": [
+        "Frankee"
+    ],
+    "Frankie Knuckles & Director's Cut": [
+        "Frankie Knuckles & Directoras Cut"
+    ],
+    "Franz & Sharp": [
+        "Franz And Shape"
+    ],
+    "Fran\u00e7ois K": [
+        "Francois K"
+    ],
+    "Fred Baker & Greg Nash": [
+        "Fred Baker vs Greg Nash"
+    ],
+    "Fred V & Grafix": [
+        "Fred V And Grafix"
+    ],
+    "Freddie Fresh": [
+        "Freddy Fresh"
+    ],
+    "Free Toyish": [
+        "Freetoyish"
+    ],
+    "Freefall": [
+        "Free Fall"
+    ],
+    "Freelance Science": [
+        "Freelance Silence"
+    ],
+    "Freeze": [
+        "Freeez"
+    ],
+    "Friction & K-Tee": [
+        "Friction & K.Tee"
+    ],
+    "Friction & Nu Balance": [
+        "Friciton And Nu Balance"
+    ],
+    "Frits Wentik": [
+        "Frits Wentink"
+    ],
+    "Fu Man Choo": [
+        "Fuman Choo"
+    ],
+    "Full Intention Presents The Rule": [
+        "Full Intension Presents The Rule"
+    ],
+    "Funk D'Void": [
+        "Funk DVoid",
+        "Funk Da Void",
+        "Funk Divoid"
+    ],
+    "Funkadelic": [
+        "Funkabelic"
+    ],
+    "Funkagenda & Exacta": [
+        "Funkagenda + Exacta"
+    ],
+    "Funkin Matt": [
+        "2 Funkin Matt"
+    ],
+    "Funky Stepz": [
+        "Funkystepz"
+    ],
+    "Funkydory": [
+        "Funkydry"
+    ],
+    "Furry Phreaks": [
+        "Furry Freaks"
+    ],
+    "Future Homosapiens": [
+        "Future Homosapienes"
+    ],
+    "Future Primitive": [
+        "Future Primitve"
+    ],
+    "Future Shock": [
+        "Futureshock"
+    ],
+    "Future Sounds Of LA": [
+        "Future Sound Of LA"
+    ],
+    "Fuzzy Logic": [
+        "Fuzzy Logik"
+    ],
+    "G Club Presents Banda Sonora": [
+        "G Club Presents Banda Sonara"
+    ],
+    "G-Force": [
+        "G Force"
+    ],
+    "G. Flame": [
+        "G Flame"
+    ],
+    "G. Flame & Mr. G": [
+        "G Flame & Mr. G"
+    ],
+    "Gabriel Ananda": [
+        "Gabrial Ananda"
+    ],
+    "Galaxy 2 Galaxy": [
+        "Galaxy To Galaxy"
+    ],
+    "Gang Starr": [
+        "Gangstarr"
+    ],
+    "Gat D\u00e9cor": [
+        "Gat Decor"
+    ],
+    "Gel Abril": [
+        "AGel Abril"
+    ],
+    "General Levy & M-Beat": [
+        "General Levy & M Beat"
+    ],
+    "George Acosta": [
+        "George Alcosta"
+    ],
+    "George Fitzgerald": [
+        "George FitzGerald"
+    ],
+    "George Kranz": [
+        "George Crans"
+    ],
+    "George Morel": [
+        "George Morell"
+    ],
+    "George Morel & SPJ": [
+        "George Morel And SPJ"
+    ],
+    "Gerait": [
+        "Gerrait"
+    ],
+    "Gil Scott-Heron": [
+        "Gil Scott\u2010Heron",
+        "Gill Scott Heron"
+    ],
+    "Gil Scott-Heron & Brian Jackson": [
+        "Gil Scott Heron & Brian Jackson"
+    ],
+    "Giselle Jackson": [
+        "Gisele Jackson"
+    ],
+    "Giuseppe Cennamo": [
+        "Giuseppe Cennamoe"
+    ],
+    "Giuseppe Ottaviani": [
+        "Guiseppe Ottaviani"
+    ],
+    "Global Communication": [
+        "Global Communications"
+    ],
+    "Gold 'n Delicious": [
+        "Gold & Delicious"
+    ],
+    "Goldfrapp": [
+        "Godfrapp"
+    ],
+    "Goldie vs Rabbit In The Moon": [
+        "Goldie vs. Rabbit In The Moon"
+    ],
+    "Gonzalez": [
+        "Gonzales"
+    ],
+    "Grandmaster Flash & Melle Mel": [
+        "Grand Master Flash And Melle Mel"
+    ],
+    "Grant Phaboa": [
+        "Grant Phabao"
+    ],
+    "Greg Churchill": [
+        "Red Churchill"
+    ],
+    "Gregor Thresher": [
+        "Gregor Tresher"
+    ],
+    "Grey Matter": [
+        "Greymatter"
+    ],
+    "Groove Armada": [
+        "Groove Aramada"
+    ],
+    "Groovebox": [
+        "Groove Box"
+    ],
+    "Gui Boratto": [
+        "Gui Borratto"
+    ],
+    "Gus Gus": [
+        "Gusgus"
+    ],
+    "Guyver": [
+        "Giyver"
+    ],
+    "Gwen McRae": [
+        "Gwen McCrae"
+    ],
+    "Gypsy Men": [
+        "Gypsy Man",
+        "Gypsymen"
+    ],
+    "H & M": [
+        "H&M"
+    ],
+    "H-Foundation": [
+        "H Foundation"
+    ],
+    "H.O.S.H.": [
+        "H.O.S.H",
+        "Hosh"
+    ],
+    "HAL 9000": [
+        "Hal 9000"
+    ],
+    "Hadouken!": [
+        "Hadouken"
+    ],
+    "Haji & Emmanuel": [
+        "Haji & Emanuel"
+    ],
+    "Hakan O'Nal": [
+        "Hakan O'Neil",
+        "Haktan O'Nal"
+    ],
+    "Hall & Oates": [
+        "Hall And Oates"
+    ],
+    "Halo Varga": [
+        "Halo Vargo"
+    ],
+    "Hard Rock Sofa & St. Brothers": [
+        "Hard Rock Sofa & St Brothers"
+    ],
+    "Hard-Fi": [
+        "Hard Fi"
+    ],
+    "Hardfloor": [
+        "Hard Floor"
+    ],
+    "Hardsoul": [
+        "Hard Soul"
+    ],
+    "Hardtrax": [
+        "Hard Traxx"
+    ],
+    "Harmonic 33": [
+        "Harmonic 313"
+    ],
+    "Harry 'Choo Choo' Romero": [
+        "Harry \"Choo Choo\" Romero"
+    ],
+    "Hatiras": [
+        "Hatirus"
+    ],
+    "Havana Funk": [
+        "Havanna Funk"
+    ],
+    "Heartthrob": [
+        "Harthrob"
+    ],
+    "Hector Cuto": [
+        "Hector Couto"
+    ],
+    "Hedningarna": [
+        "Hedingarna"
+    ],
+    "Helicopter": [
+        "Helicpoter"
+    ],
+    "Heller & Farley": [
+        "Heller And Farley",
+        "Heller and Farley"
+    ],
+    "Henrik Schwarz": [
+        "Henrick Schwarz"
+    ],
+    "Hercules & Love Affair": [
+        "Hercules And Love Affair",
+        "Hercules And The Love Affair"
+    ],
+    "Hermitude": [
+        "Hermitide"
+    ],
+    "Hernan Cattaneo & John Tinks": [
+        "Hernan Cattaneo & John Tonks"
+    ],
+    "Herv\u00e9": [
+        "Herve"
+    ],
+    "Hey Today!": [
+        "Hey Today"
+    ],
+    "Hi-Gate": [
+        "Hi Gate"
+    ],
+    "Hi-Lo": [
+        "Hi\u2010Lo"
+    ],
+    "Hi-Lo & Chocolate Puma": [
+        "Hi\u2010Lo & Chocolate Puma"
+    ],
+    "Hi-Rise": [
+        "Highrise"
+    ],
+    "High Powered Boys": [
+        "Highpowered Boys"
+    ],
+    "Hijack": [
+        "HiJack"
+    ],
+    "Hollis P. Monroe": [
+        "Hollis P Monroe"
+    ],
+    "Holt Blackheath": [
+        "Hot Blackheath"
+    ],
+    "House 2 House": [
+        "House To House"
+    ],
+    "House Syndicate": [
+        "House Sindicate"
+    ],
+    "Housemaster Boyz": [
+        "House Master Boys",
+        "Housemasterboyz",
+        "The Housemaster Boyz"
+    ],
+    "Housemaster Boyz & The Rude Boy Of House": [
+        "House Master Boyz And The Rude Boy Of House"
+    ],
+    "Howie B.": [
+        "Howie B"
+    ],
+    "Huff 'n' Puff": [
+        "Huff & Puff"
+    ],
+    "Hugg & Pep": [
+        "FHugg & Pepp",
+        "Hugg & Pepp",
+        "Hugg N Pepp"
+    ],
+    "Hunter S Thompson": [
+        "Hunter's Thompson"
+    ],
+    "Huntmann": [
+        "Huntemann"
+    ],
+    "Hyperlogic": [
+        "Hyper Logic"
+    ],
+    "Hypertrophy": [
+        "Hyper Trophy"
+    ],
+    "H\u00e5kan Lidbo": [
+        "Hakan Lidbo"
+    ],
+    "INCS": [
+        "INC S."
+    ],
+    "INXS": [
+        "Inxs"
+    ],
+    "Ignition Technician": [
+        "Ignition Technicia"
+    ],
+    "In Aura": [
+        "Inaura"
+    ],
+    "In Deep": [
+        "Indeep"
+    ],
+    "In Flagranti": [
+        "Inflagranti"
+    ],
+    "Ind.ex": [
+        "Ind.Ex"
+    ],
+    "Infinity Inc": [
+        "Infinity Ink"
+    ],
+    "Inner City": [
+        "Innercity"
+    ],
+    "Innervisions": [
+        "Innervision"
+    ],
+    "Instra:mental": [
+        "Instra:Mental"
+    ],
+    "Intexor vs. Sinesweeper": [
+        "Intexor vs Sinesweeper",
+        "Intextor vs Sine Sweeper"
+    ],
+    "Intruders": [
+        "Intruder"
+    ],
+    "Invasion Series": [
+        "Invasion Series 1"
+    ],
+    "Isac Tomita": [
+        "Isao Tomita"
+    ],
+    "Isole\u00e9": [
+        "Isol\u00e9e"
+    ],
+    "Itchy & Scratchy": [
+        "Itchy And Scratchy"
+    ],
+    "Ito & Star": [
+        "ITO & STAR"
+    ],
+    "Itty Bitty Boozy Woozy": [
+        "Itty Bitty Bozzy Woozy"
+    ],
+    "Iz-Diz": [
+        "IZ @Diz"
+    ],
+    "J & S Productions": [
+        "J @ S Productions"
+    ],
+    "J Dilla": [
+        "Jay Dilla"
+    ],
+    "J-Kwon": [
+        "J Kwon"
+    ],
+    "J-Wow": [
+        "J Wow"
+    ],
+    "J. Phlip": [
+        "J.Phlip"
+    ],
+    "J.V.C. Force": [
+        "JVC Force",
+        "Juc Force"
+    ],
+    "Jack \u00dc": [
+        "Jack J"
+    ],
+    "Jacques Da Booty": [
+        "Jaques Da Booty"
+    ],
+    "Jakatta": [
+        "Jakkata"
+    ],
+    "Jam & Spoon": [
+        "Jam And Spoon"
+    ],
+    "Jam X & De Leon": [
+        "JamX & De Leon"
+    ],
+    "James T Cotton": [
+        "James Cotton"
+    ],
+    "Jameshed": [
+        "Jamshed"
+    ],
+    "Jamie Anderson & Jesse Rose": [
+        "Jamie Anderson And Jesse Rose"
+    ],
+    "Jamie Principle": [
+        "Jamie Priciple"
+    ],
+    "Jamie Xx": [
+        "Jamie xx"
+    ],
+    "Jamieson": [
+        "Jaimeson",
+        "Jameson"
+    ],
+    "Jan Driver": [
+        "Jandriver"
+    ],
+    "Jan Johnson": [
+        "Jan Johnston"
+    ],
+    "Jark Prongo": [
+        "Jack Prongo"
+    ],
+    "Jasper Street Co.": [
+        "Jaspers Street Co"
+    ],
+    "Jay Daniel": [
+        "J Daniel"
+    ],
+    "Jay Robinson": [
+        "J. Robinson"
+    ],
+    "Jay Z": [
+        "JAY Z",
+        "JAY-Z",
+        "Jay-Z"
+    ],
+    "Jaydee": [
+        "JayDee"
+    ],
+    "Jean Phillipe Aviance": [
+        "Jean Philippe Aviance"
+    ],
+    "Jean-Jacques Perrey": [
+        "Jeah-Jacques Perrey"
+    ],
+    "Jeannie Tracy": [
+        "Jeanie Tracy"
+    ],
+    "Jennifer Lopez": [
+        "Jenifer Lopez"
+    ],
+    "Jensen Interceptor": [
+        "Jenson Interceptor"
+    ],
+    "Jephte Guillaume": [
+        "Jephte Guillame"
+    ],
+    "Jeremiah": [
+        "Jeremih"
+    ],
+    "Jesse Perez": [
+        "Jesse Velez"
+    ],
+    "Jimmy Jules": [
+        "Jimi Jules"
+    ],
+    "Jimmy Sommerville": [
+        "Jimmy Somerville"
+    ],
+    "Jimmy Spider": [
+        "Jimmy Spicer"
+    ],
+    "Joe T. Vannelli": [
+        "Joe T Vanelli",
+        "Joe T Vannelli"
+    ],
+    "Joefarr": [
+        "JoeFarr"
+    ],
+    "Joel Mull": [
+        "Joe Mull"
+    ],
+    "Joeski & DJ Chus": [
+        "Joeski And DJ Chus"
+    ],
+    "Joey Mustapha": [
+        "Joey Musaphia"
+    ],
+    "Johannes Hell": [
+        "Johannes Heil"
+    ],
+    "John '00' Fleming": [
+        "John OO Fleming"
+    ],
+    "John 'Julius' Knight": [
+        "John Julius Knight"
+    ],
+    "John Dahlb\u00e4ck": [
+        "John Dahlback",
+        "John Dalback",
+        "John Dalb\u00e4ck"
+    ],
+    "John O'Callaghan": [
+        "J.O.C",
+        "J.O.C.",
+        "JOC",
+        "John O Callaghan",
+        "John O'callaghan",
+        "John Ocallaghan"
+    ],
+    "John Tejada & Arian Leviste": [
+        "John Tegada & Arian Leviste"
+    ],
+    "John Thomas": [
+        "Jon Thomas"
+    ],
+    "Johnny Corporate": [
+        "Johhny Corporate"
+    ],
+    "Johnny Osbourne": [
+        "Jonny Osbourne"
+    ],
+    "Johnny Vicious vs MSFB": [
+        "Johnny Vicious vs MFSB"
+    ],
+    "Johnwaynes": [
+        "Jon Wayne",
+        "Jonwayne"
+    ],
+    "Jokers of the Scene": [
+        "Jokers Of The Scene"
+    ],
+    "Jon Cutler": [
+        "John Cutler"
+    ],
+    "Jon Tejada": [
+        "John Tejada"
+    ],
+    "Jon Vesta": [
+        "John Vesta"
+    ],
+    "Jon Whitemann": [
+        "John Whitemann"
+    ],
+    "Jonesey": [
+        "Jonsey"
+    ],
+    "Jonny D": [
+        "Johnny D"
+    ],
+    "Jonny L": [
+        "Johnny L"
+    ],
+    "Jori Hulkonen": [
+        "Jori Hulkkonen",
+        "Jori Hulkkonnen",
+        "Jori Hulkonnen"
+    ],
+    "Jos\u00e9 Gonz\u00e1lez": [
+        "Jose Gonzales"
+    ],
+    "Journeyman DJ": [
+        "Journey Man DJ"
+    ],
+    "Joy Kitikonti": [
+        "Joy Kiti Konti",
+        "Joy Kiticonti"
+    ],
+    "Juan Trip": [
+        "Juantrip'"
+    ],
+    "Judge Jules": [
+        "'Judge Jules"
+    ],
+    "Julius Papp": [
+        "Julias Papp"
+    ],
+    "Junkie XL": [
+        "Junkie Xl"
+    ],
+    "Jurgen Driessen": [
+        "Jarrgen Driessen",
+        "Jurgen Dressen"
+    ],
+    "Jus' Phil": [
+        "Jus Phil"
+    ],
+    "Justice & Simian": [
+        "Justice vs Simian"
+    ],
+    "K-Hand": [
+        "K Hand",
+        "K-Hand",
+        "K. Hand"
+    ],
+    "K-Klass": [
+        "K Klass"
+    ],
+    "K.W. Griff": [
+        "KW Griff",
+        "Kw Griff"
+    ],
+    "KC Flightt vs Funky Junction": [
+        "FC Flightt vs Funky Junction"
+    ],
+    "Kabale Und Liebe": [
+        "FKabale Und Liebe"
+    ],
+    "Kama Sutra": [
+        "Kamasutra",
+        "Karma Sutra"
+    ],
+    "Kamaya Painters": [
+        "Kamara Painters"
+    ],
+    "Kamikaze": [
+        "Kamakaze"
+    ],
+    "Kanine": [
+        "''Kanine"
+    ],
+    "Ken Doh": [
+        "KenDoh",
+        "Kendoh"
+    ],
+    "Ken Lou": [
+        "Kenlou"
+    ],
+    "Kenlou III": [
+        "KenLou III"
+    ],
+    "Kenny 'Dope' Gonzalez": [
+        "Kenny Dope Gonzales"
+    ],
+    "Kenny 'Jammin' Jason & Fast Eddie": [
+        "Kenny Jammin Jason & Fast Eddie"
+    ],
+    "Kenny Hawkes": [
+        "Kenny Kawkes"
+    ],
+    "Kerri Chandler": [
+        "Kerrie Chandler"
+    ],
+    "Key II Life": [
+        "Key To Life"
+    ],
+    "Keymatics": [
+        "Key-Matic"
+    ],
+    "Kid Creme": [
+        "Kid Cr\u00e8me",
+        "Kid Kreme"
+    ],
+    "Kid Cudi": [
+        "Kid Kudi"
+    ],
+    "Kid Sister": [
+        "Kidsister"
+    ],
+    "Kikumoto Allstars": [
+        "Kikomoto Allstars"
+    ],
+    "King Tubby": [
+        "King Tubbys"
+    ],
+    "Kings of Leon": [
+        "Kings Of Leon"
+    ],
+    "Kings of Tomorrow": [
+        "K.O.T",
+        "K.O.T."
+    ],
+    "Klein & MBO": [
+        "Klein & MOB",
+        "Klein And MBO"
+    ],
+    "Klubheads": [
+        "Klubbheads"
+    ],
+    "Knightlife": [
+        "Nightlife"
+    ],
+    "Kool & The Gang": [
+        "Kool And The Gang"
+    ],
+    "Korovan": [
+        "Korovin"
+    ],
+    "Kosmik Messenger": [
+        "Kosmic Messenger"
+    ],
+    "Kraak & Smaak": [
+        "Kraak & Smack"
+    ],
+    "Kraftwerk": [
+        "Kraftwork"
+    ],
+    "Kurtis Blow": [
+        "Burtis Blow"
+    ],
+    "Kyau & Albert": [
+        "Kyau vs Albert"
+    ],
+    "L'usine": [
+        "Lusine"
+    ],
+    "L.F.O vs Fuse": [
+        "LFO vs FUSE",
+        "LFO vs Fuse"
+    ],
+    "L.U.P.O.": [
+        "Lupo"
+    ],
+    "LA Williams": [
+        "La Williams"
+    ],
+    "LCD Soundsystem": [
+        "LCD Soundsytem"
+    ],
+    "LSDXOXO": [
+        "Lsdxoxo"
+    ],
+    "La Fuerza Positiva": [
+        "La Ferza Positiva"
+    ],
+    "La Luna": [
+        "Laluna"
+    ],
+    "La Tour": [
+        "LaTour",
+        "Latour"
+    ],
+    "Laidback Luke": [
+        "Laid Back Luke",
+        "Laidbackluke"
+    ],
+    "Laurent Garnier": [
+        "Lauren Garnier",
+        "Laurent Garnier's"
+    ],
+    "Layo & Bushwaka!": [
+        "Layo & Bushwacka",
+        "Layo & Bushwacka!",
+        "Layo And Bushwacka",
+        "Layo And Bushwacka!"
+    ],
+    "Le Funk Mob": [
+        "La Funk Mob"
+    ],
+    "Led Zeppelin": [
+        "Led Zepplin"
+    ],
+    "Lee Coombs": [
+        "Lee Combs"
+    ],
+    "Lee Marrow & The Love Tools": [
+        "Lee Marrow And The Love Tools"
+    ],
+    "Leon Bolier": [
+        "Leon Boiler"
+    ],
+    "Les Petit Pilous": [
+        "Les Petits Pilous"
+    ],
+    "Les Rhythmes Digitales": [
+        "Les Rythmes Digitales"
+    ],
+    "Lex Loofah": [
+        "Lex Loofer"
+    ],
+    "Lexicon Avenue": [
+        "Lexican Avenue"
+    ],
+    "Like A Time": [
+        "Like A Tim"
+    ],
+    "Lil' Jon": [
+        "Lil Jon"
+    ],
+    "Lil' Kim": [
+        "Lil Kim"
+    ],
+    "Lil' Louis": [
+        "Li'l Louis",
+        "Lil Loius",
+        "Lil\u2019 Louis"
+    ],
+    "Lil' Louis & The World": [
+        "Lil' Louis And The World"
+    ],
+    "Lil' Mo Ying Yang": [
+        "L'il Mo Ying Yang",
+        "Lil Mo Yin Yang",
+        "Lil Mo Ying Yang",
+        "Lil' Mo' Yin Yang"
+    ],
+    "Lil' Wayne": [
+        "Lil Wayne"
+    ],
+    "Lionrock": [
+        "Lion Rock"
+    ],
+    "Lisa Marie Experience": [
+        "Lias Marie Experience"
+    ],
+    "Liz Torrez": [
+        "Liz Torres"
+    ],
+    "Lo Fidelity Allstars": [
+        "Lo Fedelity AllStars"
+    ],
+    "Lo Soul": [
+        "LoSoul"
+    ],
+    "Lock 'N Load": [
+        "Lock N Load"
+    ],
+    "Loco Dice": [
+        "Locadice",
+        "Locodice"
+    ],
+    "Loletta Holloway": [
+        "''Loletta Hollaway",
+        "Loleatta Holloway"
+    ],
+    "Loni Clarke": [
+        "Loni Clark"
+    ],
+    "Lostit.Com": [
+        "Lost It.com"
+    ],
+    "Love Tattoo": [
+        "Dove Tattoo"
+    ],
+    "LoveHERTZ": [
+        "Lovehurtz"
+    ],
+    "Lovebirds": [
+        "Lovebird"
+    ],
+    "Loveshy": [
+        "Love Shy"
+    ],
+    "Luca Bacchetti": [
+        "Luca Bachetti"
+    ],
+    "Luca Lozano": [
+        "Luco Luzano"
+    ],
+    "Luca Norris": [
+        "Luca Morris"
+    ],
+    "Luv Tribe": [
+        "Love Tribe"
+    ],
+    "Luvdup": [
+        "Luv Dup"
+    ],
+    "Luvspunge": [
+        "Luv Spunge"
+    ],
+    "Lys & Gigi's": [
+        "LYS & Gigi"
+    ],
+    "L\u00fctzenkirchen": [
+        "Ludzenkirchen",
+        "Lutzenkirchen",
+        "Lutzenkirichen"
+    ],
+    "M'Boza Richie": [
+        "M'Boza Ritchi"
+    ],
+    "M-Beat": [
+        "M Beat"
+    ],
+    "M-Dubs": [
+        "M Dubs"
+    ],
+    "M-People": [
+        "M People"
+    ],
+    "M.A.N.D.Y.": [
+        "M.A.N.D.Y",
+        "Mandy"
+    ],
+    "M.A.N.D.Y. vs Booka Shade": [
+        "M.A.N.D.Y. vs Bookashade"
+    ],
+    "MBG & SDS": [
+        "MBG And SDS"
+    ],
+    "MC Shan": [
+        "M.C. Shan"
+    ],
+    "MSTRKRFT": [
+        "FMSTRKRFT"
+    ],
+    "Machinedrum": [
+        "Machindrum",
+        "Machine Drum"
+    ],
+    "Magnetic Man": [
+        "+ Magnetic Man"
+    ],
+    "Major Lazer": [
+        "? / Major Lazer",
+        "Major Lazer:",
+        "Majorlazer"
+    ],
+    "Make Some Break Some": [
+        "Makesome Breaksome"
+    ],
+    "Malcolm McLaren": [
+        "Malcom McLaren"
+    ],
+    "Man Parrish": [
+        "Man Parish",
+        "Mann Parrish"
+    ],
+    "Marc Houle": [
+        "Marc Houls"
+    ],
+    "Marc Marberg with Kyau vs. Albert": [
+        "Marc Marberg With Kyau & Albert"
+    ],
+    "Marc Mirroir": [
+        "Marc Miroir",
+        "Mark Miroir"
+    ],
+    "Marc O'Tool": [
+        "Marc O Tool"
+    ],
+    "Marc Romboy & Blake Baxter": [
+        "Marc Romboy vs Blake Baxter"
+    ],
+    "Marc et Claude": [
+        "Marc Et Claude"
+    ],
+    "Marcel Dettmann": [
+        "Macel Dettman",
+        "Marcel Dettman"
+    ],
+    "Marcellis": [
+        "Marcelus"
+    ],
+    "Marcello Casteli": [
+        "Marcelo Castelli"
+    ],
+    "Marco Corolla": [
+        "Marco Carola",
+        "Marco Corola"
+    ],
+    "Marco V": [
+        "Marcov"
+    ],
+    "Maria Naylor": [
+        "Maria Nayler"
+    ],
+    "Mariah Carey": [
+        "Maria Carey"
+    ],
+    "Marino Berradi": [
+        "Marino Beradi",
+        "Marino Berardi"
+    ],
+    "Mario Picotto": [
+        "Mauro Picotto"
+    ],
+    "Mario Pui": [
+        "Mario Piu",
+        "Mauro Piu"
+    ],
+    "Mark De Clive-Lowe": [
+        "Mark De Clive Lowe"
+    ],
+    "Mark Greene": [
+        "Mark Green"
+    ],
+    "Mark Henning": [
+        "Mark-Henning"
+    ],
+    "Mark Knight & D.Ramirez": [
+        "Mark Knight & D Ramirez",
+        "Mark Knight + D Ramirez"
+    ],
+    "Mark Knight & Funkagenda": [
+        "Mark Knight + Funkagenda"
+    ],
+    "Mark N-R-G": [
+        "Mark NRG"
+    ],
+    "Markus Nikolai": [
+        "Markus Nikolti"
+    ],
+    "Marley Marl": [
+        "Marly Marl"
+    ],
+    "Marta Acuna": [
+        "Martina Acuna"
+    ],
+    "Martha Walsh": [
+        "Martha Wash"
+    ],
+    "Martin Garrix & Jay Hardway": [
+        "Martin Garrix And Jay Hardway"
+    ],
+    "Martin Solvieg": [
+        "Martin Solveig"
+    ],
+    "Mary J. Blige": [
+        "Mary J Blige"
+    ],
+    "Mary Kiani": [
+        "Kary Kiani",
+        "Mari Kiani"
+    ],
+    "Mastiksoul": [
+        "MastikSoul"
+    ],
+    "Mathew Jonson": [
+        "Matthew Jhonson"
+    ],
+    "Mathias Mestino": [
+        "Mathias Mesteno"
+    ],
+    "Matrix & Futurebound": [
+        "Matrix And Futurebound",
+        "Metrik And Futurebound"
+    ],
+    "Matteo DiMarr": [
+        "Matteo Dimarr"
+    ],
+    "Matthew Dekay And Proluctors": [
+        "Matthew Dekay Vs. Proluctors"
+    ],
+    "Matthias Heilbronn": [
+        "Natthias Heilbronn"
+    ],
+    "Matthias Meyer": [
+        "Mattias Meyer"
+    ],
+    "Matthias Tanzmann": [
+        "Mattias Tanzmann"
+    ],
+    "Maurice & Noble": [
+        "Maurice And Noble"
+    ],
+    "Mauve & Movearo": [
+        "Mauve + Movearo"
+    ],
+    "Maya Jane Coles": [
+        "''Maya Jane Coles",
+        "Maya Janes Cole"
+    ],
+    "Mephista": [
+        "Mephisto"
+    ],
+    "Method Man": [
+        "Method Men"
+    ],
+    "Metric": [
+        "Metrik"
+    ],
+    "Metro Area": [
+        "Metro Area 4"
+    ],
+    "Michael Cleisz": [
+        "Michel Cleis"
+    ],
+    "Michael Gray": [
+        "Michael Grey"
+    ],
+    "Michael Ho": [
+        "Michal Ho",
+        "Michel Ho"
+    ],
+    "Michael Proctor": [
+        "Michael Procter"
+    ],
+    "Michael Watford": [
+        "Micael Watford"
+    ],
+    "Michael Woods": [
+        "Micheal Woods"
+    ],
+    "Michel De Hey & Grooveyard": [
+        "Michel De Hey vs Grooveyard"
+    ],
+    "Michel De Hey & Secret Cinema": [
+        "Michel De Hey vs Secret Cinema"
+    ],
+    "Michel De Hey vs Literon": [
+        "Michel Dehey vs Literon"
+    ],
+    "Mick Burns": [
+        "Mic Burns"
+    ],
+    "Mick Willis": [
+        "Mick Wills"
+    ],
+    "Midnight Juggernauts": [
+        "Midnight Juggernaughts"
+    ],
+    "Mighty Dub Katz": [
+        "Mighty Dub Cats",
+        "Mighty Dub Kats"
+    ],
+    "Miguel Migs": [
+        "Manuel Migs"
+    ],
+    "Mihalis Safras": [
+        "''Mihalis Safras"
+    ],
+    "Mike Ink": [
+        "Mike Inc."
+    ],
+    "Mike Koglin": [
+        "Mike Coglin"
+    ],
+    "Mike Snow": [
+        "Miike Snow"
+    ],
+    "Mikey Dread": [
+        "Mike Dred"
+    ],
+    "Millenium": [
+        "Milenium",
+        "Milennium"
+    ],
+    "Millionaire Hippies": [
+        "Millionare Hippies"
+    ],
+    "Minimal Funk": [
+        "Minimal Funk 2"
+    ],
+    "Minimalistix": [
+        "Minimalistics"
+    ],
+    "Ministers De Le Funk": [
+        "Minister De La Funk"
+    ],
+    "Mirrorball": [
+        "Mirror Ball"
+    ],
+    "Miss Kitten": [
+        "Miss Kittin"
+    ],
+    "Missy Elliott": [
+        "Missy Eliot",
+        "Missy Elliot"
+    ],
+    "Mistress Barbara": [
+        "Misstress Barbara"
+    ],
+    "Mochic": [
+        "Moshic"
+    ],
+    "Modeselektor": [
+        "Mode Selector"
+    ],
+    "Mogwai": [
+        "Moguai",
+        "Moogwai"
+    ],
+    "Monolink": [
+        "Mhonolink"
+    ],
+    "Monsta": [
+        "MONSTA"
+    ],
+    "Moodymann": [
+        "Moodymanc"
+    ],
+    "Morel's Groove": [
+        "Morel's Grooves"
+    ],
+    "Morphology": [
+        "Morphologhy"
+    ],
+    "Mory Kant\u00e9": [
+        "Mory Kante"
+    ],
+    "Most Wanted": [
+        "Wost Wanted"
+    ],
+    "Move Ya! & Steve Lavers": [
+        "Move Ya & Steve Lavers"
+    ],
+    "Mr. G": [
+        "MR G"
+    ],
+    "Mr. Jacks": [
+        "Mr. Jack"
+    ],
+    "Mr. Scruff": [
+        "Mr Scruff"
+    ],
+    "Mr. Sliff": [
+        "Mr Sliff"
+    ],
+    "Mr. Tophat & Art Alfie": [
+        "Mr. Tophie & Art Alfie"
+    ],
+    "Mr.Oizo": [
+        "Mr Oizo",
+        "Mr Ozio",
+        "Mr. Oizo",
+        "Mr. Ozio"
+    ],
+    "Mrs Woods": [
+        "Mrs Wood"
+    ],
+    "Mssingno": [
+        "MssingNo"
+    ],
+    "Music Cargo": [
+        "Musiccargo"
+    ],
+    "Muzziak": [
+        "Muzzaik",
+        "Muzzak"
+    ],
+    "Mvsevm": [
+        "Mvsvem"
+    ],
+    "N.E.R.D.": [
+        "N*E*R*D",
+        "N.E.R.D",
+        "Nerd"
+    ],
+    "N.O.H.A.": [
+        "Noha"
+    ],
+    "NT89": [
+        "Nt89"
+    ],
+    "NVOY": [
+        "Envoi",
+        "Envoy"
+    ],
+    "NY Connection": [
+        "N.Y. Connection"
+    ],
+    "Nalin & Kane": [
+        "Nalin And Kane"
+    ],
+    "Nathan Cole": [
+        "Nathan Coles"
+    ],
+    "Nemesis": [
+        "Nemesi"
+    ],
+    "Nero": [
+        "NERO",
+        "Nero"
+    ],
+    "Niagra": [
+        "Niagara"
+    ],
+    "Nic Fanciulli": [
+        "Nic Fancuilli"
+    ],
+    "Nick & Danny Chatelain": [
+        "Nick & Danny Chaterlain",
+        "Nick And Danny Chatelain"
+    ],
+    "Nick Sentience": [
+        "Nick Sentence"
+    ],
+    "Nicky Romero & Nervo": [
+        "Nicky Romero & Nero"
+    ],
+    "Niki & The Dove": [
+        "Niki And The Dove"
+    ],
+    "Njoi vs Tact": [
+        "Njoy vs Tact"
+    ],
+    "Noise Controllers": [
+        "Noisecontrollers"
+    ],
+    "Noisia": [
+        "Noisa"
+    ],
+    "Noisia & The Upbeats": [
+        "Noisia vs The Upbeats"
+    ],
+    "Notorious B.I.G.": [
+        "Notorious BIG",
+        "The Notorious B.I.G."
+    ],
+    "Novy V Eniac": [
+        "Novy vs Eniac",
+        "Novy. vs Eniac"
+    ],
+    "Nu Yorican Soul": [
+        "Nu Yoricon Soul",
+        "Nuyorican Soul"
+    ],
+    "Nu-Birth": [
+        "Nu Birth"
+    ],
+    "Nu-Nrg": [
+        "Nu NRG"
+    ],
+    "Nu:Tone": [
+        "Nu Tone"
+    ],
+    "Nucleus": [
+        "Newcleus"
+    ],
+    "N\u00f4ze": [
+        "Noze"
+    ],
+    "N\u00fcw Idol": [
+        "Nuw Idol"
+    ],
+    "O.D.B.": [
+        "ODB"
+    ],
+    "O.T. Quartet": [
+        "Q.T. Quartet",
+        "QT Quartet",
+        "The OT Quartet"
+    ],
+    "Old Skool Immortal": [
+        "Old School Immortal"
+    ],
+    "Oliver Berger": [
+        "Olivier Berger"
+    ],
+    "Oliver Dodd": [
+        "Oliver Bodd"
+    ],
+    "Oliver Huntemann": [
+        "Oliver Hunteman"
+    ],
+    "Oliver Lieb": [
+        "Oliver Leib"
+    ],
+    "Oliver Moldan": [
+        "Oliver Molden"
+    ],
+    "Omega Man": [
+        "Omegaman"
+    ],
+    "Omni Trio": [
+        "Onmi Trio"
+    ],
+    "One Dove": [
+        "Onedove"
+    ],
+    "Oneohtrix Point Never": [
+        "OneOhTrixPointNever"
+    ],
+    "Onionz": [
+        "Onoinz"
+    ],
+    "On\u00fcr Ozer": [
+        "Onur Ozer",
+        "Onur \u00d6zer"
+    ],
+    "Orange": [
+        "Orang"
+    ],
+    "Original Sin & Taxman": [
+        "Original Sin And Taxman"
+    ],
+    "Ortus": [
+        "Orties"
+    ],
+    "Os Mutantes": [
+        "Osmutantes"
+    ],
+    "Oscar G. & Ralph Falcon": [
+        "Oscar G & Ralph Falcon"
+    ],
+    "Oscar Molero": [
+        "Oscar Mulero"
+    ],
+    "Outkast": [
+        "OutKast",
+        "Outcast"
+    ],
+    "Outwerk": [
+        "OutWork",
+        "Outwork"
+    ],
+    "P-Money": [
+        "P Money"
+    ],
+    "Paganini Traxx": [
+        "Paginini Traxx"
+    ],
+    "Paint": [
+        "PAINT"
+    ],
+    "Pangea": [
+        "Pangaea"
+    ],
+    "Pants & Corsets": [
+        "Pants & Corset"
+    ],
+    "Paolo Mojo": [
+        "Paulo Mojo"
+    ],
+    "Par-T-One vs INXS": [
+        "Par-T-One vs. INXS"
+    ],
+    "Para One": [
+        "Paraone"
+    ],
+    "Paris & Healey": [
+        "Paris And Healey"
+    ],
+    "Paris & Sharpe": [
+        "Paris & Sharp",
+        "Paris + Sharpe",
+        "Paris And Sharpe"
+    ],
+    "Partison": [
+        "Partision"
+    ],
+    "Pascal F.E.O.S.": [
+        "Pascal FEOS"
+    ],
+    "Patric La Funk": [
+        "Patrick La Funk"
+    ],
+    "Patterson & Price": [
+        "Paterson & Price"
+    ],
+    "Paul C & Paolo Martini": [
+        "Paul C & Paulo Martini"
+    ],
+    "Paul Hunter": [
+        "Paul Hunder"
+    ],
+    "Paul Kalkbrenner": [
+        "Paul Kalbrenner"
+    ],
+    "Paul van Dyk": [
+        "Paul Van Dyk"
+    ],
+    "Paul van Dyk & Alex M.O.R.P.H.": [
+        "Paul Van Dyk & Alex M.O.R.P.H."
+    ],
+    "Pauline Taylor": [
+        "Pauline Talyor"
+    ],
+    "Pearson Sound": [
+        "Person Sound"
+    ],
+    "Pete Heller & Tedd Patterson Pres. The Look & Feel": [
+        "Pete Heller And Tedd Patterson Pres. The Look And Feel"
+    ],
+    "Pete Lazonby": [
+        "Peter Lazonby"
+    ],
+    "Pete Tong & Paul Rodgers": [
+        "Pete Tong & Paul Rogers"
+    ],
+    "Peter Katafalk": [
+        "Peter Katalfalk"
+    ],
+    "Peter van Hoesen": [
+        "Peter Van Hoesen"
+    ],
+    "Petra & Co": [
+        "Petra And Co."
+    ],
+    "Phil Kieran": [
+        "Phil Kieren",
+        "Phil Kieron"
+    ],
+    "Philippe B": [
+        "Phillipe B",
+        "Pillippe B"
+    ],
+    "Phobia": [
+        "PHOBIA"
+    ],
+    "Photek": [
+        "Photec"
+    ],
+    "Photon Inc.": [
+        "Photon Inc"
+    ],
+    "Phunk Phorce": [
+        "Phlink Phorce"
+    ],
+    "Phunky Data": [
+        "Funky Data"
+    ],
+    "Pierre's Fantasy Club": [
+        "Pierre Fantasy Club",
+        "Pierre's Pfantasy Club"
+    ],
+    "Pig Force": [
+        "Pigforce"
+    ],
+    "Pirates Of The Carribean": [
+        "Pirates Of The Carribbean"
+    ],
+    "Pitch Black": [
+        "Pitchblack"
+    ],
+    "Planisphere": [
+        "Planishere"
+    ],
+    "Plastic Avengers": [
+        "Plastic Avenger"
+    ],
+    "Plastikman": [
+        "Plasticman",
+        "Plastiman"
+    ],
+    "Plump DJs": [
+        "Plump DJ's"
+    ],
+    "Plumps": [
+        "The Plumps"
+    ],
+    "Pob": [
+        "POB"
+    ],
+    "Poltergeist": [
+        "Polterguist"
+    ],
+    "Popof": [
+        "PoPoF"
+    ],
+    "Portobella": [
+        "Portabella"
+    ],
+    "Potential Bad Boy": [
+        "Potential Badboy"
+    ],
+    "Power Dove": [
+        "Powerdove"
+    ],
+    "Prassay": [
+        "Prrassay"
+    ],
+    "Prince & The Revolution": [
+        "Prince And The Revolution"
+    ],
+    "Problem Kidz pres. Buddy Booth": [
+        "Problem Kidz Pres. Buddy Booth"
+    ],
+    "Project X": [
+        "Pro-Ject X"
+    ],
+    "Propellerheads": [
+        "Propellaheads",
+        "Propeller Heads"
+    ],
+    "Proxy": [
+        "The Proxy"
+    ],
+    "Psychik Warriors Ov Gaia": [
+        "Psychick Warriors Ov Gaia"
+    ],
+    "P\u00e9p\u00e9 Bradock": [
+        "Pepe Braddock",
+        "Pepe Bradock",
+        "Pete Bradock"
+    ],
+    "Q-Burns Abstract Message": [
+        "Q Burn's Abstract Message"
+    ],
+    "Q-Club": [
+        "Q Club"
+    ],
+    "Q-Project": [
+        "Q Project"
+    ],
+    "Q-Tip": [
+        "Q Tip",
+        "Qtip"
+    ],
+    "Quasistereo": [
+        "Qugisistereo"
+    ],
+    "Queens Of The Stone Age": [
+        "Queens Of The Stoneage"
+    ],
+    "R-Tyme": [
+        "R Tyme"
+    ],
+    "R.E.M.": [
+        "REM"
+    ],
+    "R3hab, Nervo & Ummet Ozcan": [
+        "R3hab & NERVO & Ummet Ozcan"
+    ],
+    "RAM Trilogy": [
+        "Ram Trilogy"
+    ],
+    "RL Grime": [
+        "Rl Grime"
+    ],
+    "Rabbit In The Moon": [
+        "Rabbit In The Mood"
+    ],
+    "Rachael Starr": [
+        "Rachel Starr"
+    ],
+    "Rack N Ruin": [
+        "Racknruin"
+    ],
+    "Radio Slave": [
+        "Radioslave"
+    ],
+    "Radiohead": [
+        "Radio Head"
+    ],
+    "Raffa FL": [
+        "Raffa Fl"
+    ],
+    "Rage Against The Machine": [
+        "Rage Against the Machine"
+    ],
+    "Ralph Rosario": [
+        "Ralph Rosaro",
+        "Ralphi Rosario"
+    ],
+    "Ramadanman & Appleblim": [
+        "Ramadanman + Appleblim"
+    ],
+    "Ramon La Four": [
+        "Ramon Lafour"
+    ],
+    "Random Factor": [
+        "Randon Factor"
+    ],
+    "Randy Katana": [
+        "- Randy Katana"
+    ],
+    "Rare Arts": [
+        "Rare Earth"
+    ],
+    "Raven Maize": [
+        "Raven Maze"
+    ],
+    "Re:locate": [
+        "Re:Locate"
+    ],
+    "Real McCoy": [
+        "Real McKoy"
+    ],
+    "Red Hot Chilli Peppers": [
+        "''Red Hot Chili Peppers",
+        "Red Hot Chili Peppers",
+        "Ret Hot Chilli Peppers"
+    ],
+    "Redinho": [
+        "Redhino"
+    ],
+    "Redlight": [
+        "Red Light"
+    ],
+    "Redlight feat. Ms. Dynamite": [
+        "Redlight Feat. Ms. Dynamite"
+    ],
+    "Reel 2 Reel": [
+        "Reel 2 Real"
+    ],
+    "Reese & Santonio": [
+        "Reese And Santonio"
+    ],
+    "Rek Shit Rebulz": [
+        "Reck Shit Rebulz"
+    ],
+    "Remo-Con": [
+        "Remo Con"
+    ],
+    "Remy & Roland Klinkenberg": [
+        "Remy And Roland Klinkenberg"
+    ],
+    "Ren-D": [
+        "Ran-D"
+    ],
+    "Renaissance Man": [
+        "Rennaissance Man"
+    ],
+    "Rennie Pilgrem": [
+        "Rennie PIlgrem",
+        "Rennie Pilgrim"
+    ],
+    "Ren\u00e8 Amesz": [
+        "Rene Amesz"
+    ],
+    "Ren\u00e9 LaVice": [
+        "Rene La Vice",
+        "Rene LaVice",
+        "Rene Lavice",
+        "Ren\u00e9 Lavice"
+    ],
+    "Rhythm Controll": [
+        "F+ Rhythm Controll"
+    ],
+    "Rhythm Is Rhythm": [
+        "Rhythim Is Rhythim"
+    ],
+    "Ricardo Villalobos": [
+        "Ricardo Villalolobos"
+    ],
+    "Richard Durand": [
+        "Richard Durrand"
+    ],
+    "Richard F.": [
+        "Richard F"
+    ],
+    "Richie Dane": [
+        "Richie Dan"
+    ],
+    "Rick Wihite": [
+        "Rick Wilhite"
+    ],
+    "Ricky L": [
+        "Rick L"
+    ],
+    "Ricky Leroy": [
+        "Ricky Le Moy"
+    ],
+    "Rico Tubbs": [
+        "Ricco Tubbs"
+    ],
+    "Rimbaudin": [
+        "Rimbaudian"
+    ],
+    "Riva Starr": [
+        "Rivastar"
+    ],
+    "Roach Motel": [
+        "Roach Montel"
+    ],
+    "Rob Base & DJ E-Z Rock": [
+        "Rob Base And DJ E-Z Rock"
+    ],
+    "Robag Whrume": [
+        "Robag Wruhme"
+    ],
+    "Robert Burian": [
+        "Robbert Burian"
+    ],
+    "Robert Dietz": [
+        "Roberto Dietz"
+    ],
+    "Robert Owens": [
+        "Obert Owens",
+        "Robert Ownes"
+    ],
+    "Robin S.": [
+        "Robin S"
+    ],
+    "Robin S. vs Steve Angello & Laidback Luke": [
+        "Robin S vs Steve Angello And Laidback Luke"
+    ],
+    "Rodriguez Jr.": [
+        "Rodriguez Jr"
+    ],
+    "Roger S.": [
+        "Roger S"
+    ],
+    "Rok & Kato": [
+        "Roc & Kato"
+    ],
+    "Roland Kleinenberg": [
+        "Roland Klinkenberg"
+    ],
+    "Romain & Danny Krivit": [
+        "Roman & Danny Kriuit"
+    ],
+    "Ron Carroll": [
+        "Ron Carol",
+        "Ron Carrol"
+    ],
+    "Ron Van Den Beuken": [
+        "Ron Van De Beuken",
+        "Ron van den Beuken"
+    ],
+    "Ronald Van Gelderen": [
+        "Ronald Van Gelderan",
+        "Ronald van Gelderen"
+    ],
+    "Ronaldo's Revenge": [
+        "Ronaldos Revenge"
+    ],
+    "Roni Size & Reprazent": [
+        "Roni Size / Reprazent"
+    ],
+    "Rosie Gaines": [
+        "Roise Gaines",
+        "Rosie Gains"
+    ],
+    "Round One": [
+        "Bound One"
+    ],
+    "Roy Davis Jr.": [
+        "Roy David JR",
+        "Roy Davies",
+        "Roy Davis",
+        "Roy Davis JR",
+        "Roy Davis Jnr",
+        "Roy Davis Jr"
+    ],
+    "Rrose": [
+        "RRose"
+    ],
+    "Ruff Driverz": [
+        "Ruff Drivers"
+    ],
+    "Ruffneck": [
+        "Ruffnick"
+    ],
+    "Rufus & Chaka Khan": [
+        "Rufus And Chaka Khan"
+    ],
+    "Rui Da Silva": [
+        "Rui Da Silver"
+    ],
+    "Ryuchi Sakamoto": [
+        "Riuichi Sakamoto",
+        "Riyuchi Sakamoto",
+        "Ryuichi Sakamoto"
+    ],
+    "R\u00f3is\u00edn Murphy": [
+        "Roisin Murphy"
+    ],
+    "R\u00f6yksopp": [
+        "Royksopp"
+    ],
+    "R\u00f8dh\u00e5d": [
+        "Redhead"
+    ],
+    "R\u00fcf\u00fcs": [
+        "Rufus",
+        "R\u00dcF\u00dcS"
+    ],
+    "S-Express": [
+        "S'Express"
+    ],
+    "S.C.B.": [
+        "SCB"
+    ],
+    "S.P.Y.": [
+        "S.P.Y",
+        "S.P.Y.",
+        "S.p.y.",
+        "SPY",
+        "Spy"
+    ],
+    "SOB": [
+        "S.O.B."
+    ],
+    "Sahira Moore": [
+        "Sahirah Moore"
+    ],
+    "Sain PT2": [
+        "Sain PT3"
+    ],
+    "Saint Ettienne": [
+        "Saint Etienne"
+    ],
+    "Saints & Sinners": [
+        "Saints & Sinner"
+    ],
+    "Sam Mollison": [
+        "Sam Molinson"
+    ],
+    "Samiyam": [
+        "SAMIYAM"
+    ],
+    "Samuel L. Sessions": [
+        "Samual L Session",
+        "Samuel L Session",
+        "Samuel L. Session",
+        "Samuel Session"
+    ],
+    "Sander van Doorn": [
+        "Sander Van Doorn"
+    ],
+    "Sandrino & Frankey": [
+        "Sandrino Frankey"
+    ],
+    "Sandy Riviera": [
+        "Sandy Rivera"
+    ],
+    "Santagold": [
+        "Santogold"
+    ],
+    "Sanxzero": [
+        "SanXero"
+    ],
+    "Sascha Funkye": [
+        "Sascha Funke"
+    ],
+    "Sasha & Emerson": [
+        "Sasha / Emerson"
+    ],
+    "Satoshi Tomie": [
+        "Satoshi Tomei",
+        "Satoshi Tomiie",
+        "Satoshi Tomillie",
+        "Satoshie Tomie",
+        "Satoshie Tomilie"
+    ],
+    "Savannah": [
+        "Savana"
+    ],
+    "Savile": [
+        "Saville"
+    ],
+    "Scan 7": [
+        "Scan7"
+    ],
+    "Scanty Sandwich": [
+        "Scanty Sandwhich"
+    ],
+    "Schooly D": [
+        "Schoolly-D"
+    ],
+    "Scooter": [
+        "Scotter"
+    ],
+    "Scott Deep": [
+        "Scotti Deep"
+    ],
+    "Scott Grooves": [
+        "Scott Groove"
+    ],
+    "Scratch Perverts": [
+        "Scatch Perverts"
+    ],
+    "Seb Fontaine & Jay P": [
+        "Seb Fontaine And Jay P"
+    ],
+    "Sebastian": [
+        "SebastiAn"
+    ],
+    "Sebo K & Metro": [
+        "Sebo K And Metro"
+    ],
+    "Second Hand Satellites": [
+        "Second Hand Satelites",
+        "Second Hand Satellite"
+    ],
+    "Secret Cinema": [
+        "Secret Cinema 2"
+    ],
+    "Serge Gainsbourg": [
+        "Sergie Gainsbourg"
+    ],
+    "Sessamotto": [
+        "Sessomatto"
+    ],
+    "Seven Davis Jr.": [
+        "Seven Davis Jr"
+    ],
+    "Shadow Child & T. Williams": [
+        "Shadow Child and T. Williams"
+    ],
+    "Shadows Movement": [
+        "Shadow Movement"
+    ],
+    "Sharam Jey & Nick K": [
+        "Sharam Jay And Nick K",
+        "Sharam Jey And Nick K"
+    ],
+    "Shenoda": [
+        "Shenonda"
+    ],
+    "Shi-Take": [
+        "Shi Take"
+    ],
+    "Shindoe": [
+        "Shinedoe"
+    ],
+    "Shirley Bassey": [
+        "Shirley Bassy"
+    ],
+    "Shit Robot": [
+        "Sh*t Robot"
+    ],
+    "Shl\u00f8mo": [
+        "Shlohmo"
+    ],
+    "Shock One": [
+        "ShockOne"
+    ],
+    "Shur-I-Kan": [
+        "Shur-I-Khan"
+    ],
+    "Sidekick": [
+        "Side Kick"
+    ],
+    "Sidney Samson": [
+        "+ Sidney Samson",
+        "Sydney Sampson",
+        "Sydney Samson"
+    ],
+    "Sieg \u00fcber Die Sonne": [
+        "Sieg Uber Die Sonne"
+    ],
+    "Sigma 2": [
+        "Sigma"
+    ],
+    "Signalrunners": [
+        "Signal Runners"
+    ],
+    "Silicone Soul": [
+        "Silicon Soul"
+    ],
+    "Simian Mobile Disco & Roman Fl\u00fcgel": [
+        "Simian Mobile Disco & Roman Flaggel"
+    ],
+    "Simms & Welt": [
+        "Simms And Welt"
+    ],
+    "Singles & Angles": [
+        "Singles And Angles"
+    ],
+    "Sin\u00e9ad OConnor": [
+        "Sinead O'Connor"
+    ],
+    "Sisqo": [
+        "Sisko"
+    ],
+    "Skream!": [
+        "Scream",
+        "Skream"
+    ],
+    "Skullduggery": [
+        "Skull Duggery"
+    ],
+    "Skylark": [
+        "Sky Lark"
+    ],
+    "Skymaster": [
+        "Sky Master"
+    ],
+    "Sleazy McQueen": [
+        "Sleazy Mcqueen"
+    ],
+    "Sleep Archive": [
+        "Sleeparchive"
+    ],
+    "Slow Moshun": [
+        "Slo Moshum",
+        "Slo Moshun"
+    ],
+    "Small People": [
+        "Smallpeople"
+    ],
+    "Smith & Mighty": [
+        "Smith And Mighty"
+    ],
+    "Smith'n'Hack": [
+        "Smith And Hack",
+        "Smith N Hack"
+    ],
+    "Smitty & Eric Davenport": [
+        "Smitty And Eric Davenport"
+    ],
+    "Solarstone": [
+        "Solar Stone"
+    ],
+    "Solid Sessions": [
+        "Solid Session"
+    ],
+    "Sonic C.": [
+        "Sonic C"
+    ],
+    "Soul Drivers": [
+        "Soul Driver",
+        "Souldrivers"
+    ],
+    "Soul Grabber": [
+        "Soulgrabber",
+        "Soulgrabber 4"
+    ],
+    "Soul Mate": [
+        "Soulmate"
+    ],
+    "Soul Sonic Force": [
+        "Soulsonic Force"
+    ],
+    "Sound Design": [
+        "Sound De-Zign"
+    ],
+    "Sound Stream": [
+        "Soundstream"
+    ],
+    "Soundclash Republic": [
+        "Sound Clash Republic"
+    ],
+    "South Street Players": [
+        "South Street Player"
+    ],
+    "Southside Hustlers": [
+        "South Side Hustlers"
+    ],
+    "Space DJz": [
+        "Space DJs"
+    ],
+    "Space Dust": [
+        "Spacedust"
+    ],
+    "Space Manoeuvers": [
+        "Space Manoeuvres",
+        "Space Manouvers"
+    ],
+    "Spectrasoul": [
+        "SpectraSoul"
+    ],
+    "Spectrum": [
+        "Specktrum",
+        "Spektrum"
+    ],
+    "Speedy J & Chris Liebing": [
+        "Speedy J And Chris Liebing"
+    ],
+    "Splitter": [
+        "Splittr"
+    ],
+    "Spoiled & Zigo": [
+        "Spolied And Zigo"
+    ],
+    "St. Germain": [
+        "St Germain",
+        "St.Germain"
+    ],
+    "Stacey Kid": [
+        "Stacy Kidd"
+    ],
+    "Stanny Franssen": [
+        "Stanny Fransen"
+    ],
+    "Stardust": [
+        "Startdust"
+    ],
+    "Starfighter": [
+        "Starfighters",
+        "Startfighter"
+    ],
+    "Starkillers & Dmitry Ko": [
+        "Starkillers & Dmitry KO"
+    ],
+    "Stefan Goldmann": [
+        "Stefan Goldman"
+    ],
+    "Steff, Pako & Fredrick": [
+        "Stef, Pako & Frederick"
+    ],
+    "Stephan Bodzin & Marc Romboy": [
+        "Stephan Bodzin and Marc Romboy",
+        "Stephan Bodzin vs Marc Romboy"
+    ],
+    "Stephane Luke": [
+        "Stephan Luke"
+    ],
+    "Stephen Bodzin": [
+        "Stephan Bodzin"
+    ],
+    "Stephen J. Kroos": [
+        "Stephan J Kroos"
+    ],
+    "Stereo MCs": [
+        "Stereo MC's"
+    ],
+    "Stetsasonic": [
+        "Stetsaonic"
+    ],
+    "Steve 'Silk' Hurley": [
+        "Steve Silk Hurley"
+    ],
+    "Steve Angello & Laidback Luke": [
+        "Steve Angello And Laidback Luke"
+    ],
+    "Steve Angello & Sebastian Ingrosso": [
+        "Steve Angello & Sebastain Ingrosso",
+        "Steve Angelo & Sebastian Ingrosso"
+    ],
+    "Steve Angello vs Matisse & Sadko": [
+        "Steve Angello & Matisse & Sadko"
+    ],
+    "Steve Mac & Mark Brown": [
+        "Steve Mac And Mark Brown"
+    ],
+    "Stingray 313": [
+        "Stingray313"
+    ],
+    "Stix & Stoned": [
+        "Stix And Stoned"
+    ],
+    "Stonebridge": [
+        "StoneBridge"
+    ],
+    "Stretch & Vern Presents Michel Lombert": [
+        "Stretch & Vern Presente Michel Lombert"
+    ],
+    "Stretch 'N' Vern": [
+        "Stretch & Vern",
+        "Stretch N Vern"
+    ],
+    "Stylophonic": [
+        "Stylophonics"
+    ],
+    "Subfocus": [
+        "Sub Focus",
+        "SubFocus"
+    ],
+    "Subjective": [
+        "The Subjective"
+    ],
+    "Sucker DJs": [
+        "Sucker DJ's"
+    ],
+    "Sugar Shack": [
+        "Sugar Shake"
+    ],
+    "Sulfurex": [
+        "Sulphrex"
+    ],
+    "Sultan & Ned Shepherd": [
+        "Sultan & Ned Shepard"
+    ],
+    "Sunscreem": [
+        "Sunscream"
+    ],
+    "Swedish House Mafia & Knife Party": [
+        "Swedish House Mafia vs Knife Party"
+    ],
+    "Sweet N' Candy": [
+        "Swet N Candy"
+    ],
+    "Sweetlight": [
+        "Sweet Light"
+    ],
+    "Sylvester": [
+        "Sulvester",
+        "Sylvesta"
+    ],
+    "Syndicate Of L.A.W.": [
+        "Syndicate Of Law"
+    ],
+    "System VIII": [
+        "Systemm VIII"
+    ],
+    "S\u00e9bastien L\u00e9ger": [
+        "FS\u00e9bastien L\u00e9ger",
+        "Sebastian Leger",
+        "Sebastien Leger",
+        "S\u00e9bastien Leger"
+    ],
+    "S\u00e9bastien Tellier": [
+        "Sebasien Tellier",
+        "Sebastian Tellier",
+        "Sebastien Tellier"
+    ],
+    "S\u00e9rgio Mendes": [
+        "Sergio Mendez"
+    ],
+    "T-Coy": [
+        "Tcoy"
+    ],
+    "T-Empo": [
+        "T'Empo"
+    ],
+    "TC Crew": [
+        "Tc Crew"
+    ],
+    "TPH & WJH": [
+        "TPH / WJH"
+    ],
+    "Tanita Tikaram": [
+        "Tanika Tikaram"
+    ],
+    "Taras Van De Voorde": [
+        "Taras Van Der Voorde"
+    ],
+    "Taylor Dayne": [
+        "Talyor Dayne"
+    ],
+    "Team SR": [
+        "Teams Sr"
+    ],
+    "Technocat": [
+        "Techno Cat"
+    ],
+    "Teddy Douglas & Luis Radio": [
+        "Teddy Douglas, Luis Radio"
+    ],
+    "Tencity": [
+        "Ten City"
+    ],
+    "Tenth Chapter": [
+        "Tenth Capter"
+    ],
+    "Terpischord": [
+        "Terpischord 3"
+    ],
+    "Terra Firma": [
+        "Terra Ferma"
+    ],
+    "Terry Ferminal": [
+        "2 Terry Ferminal"
+    ],
+    "Terry Lee Brown Jr.": [
+        "Terry Lee Brown Jr"
+    ],
+    "ThatManMonkz": [
+        "thatmanmonkz"
+    ],
+    "The 45 Kings": [
+        "45 King"
+    ],
+    "The 6400 Crew": [
+        "6400 Crew"
+    ],
+    "The Abbyssinians": [
+        "The Abyssinians"
+    ],
+    "The Absolute": [
+        "Absolute"
+    ],
+    "The Advent": [
+        "Advent"
+    ],
+    "The Alan Parsons Project": [
+        "Alan Parsons Project"
+    ],
+    "The Aloof": [
+        "Aloof"
+    ],
+    "The Ark": [
+        "Ark"
+    ],
+    "The Art Of Noise": [
+        "Art Of Noise"
+    ],
+    "The B Boys": [
+        "B Boys"
+    ],
+    "The Backout All Stars": [
+        "Blackout Allstars"
+    ],
+    "The Bar-Kays": [
+        "The Bar Kays"
+    ],
+    "The Beach Boys": [
+        "Beach Boys"
+    ],
+    "The Beastie Boys": [
+        "Beaste Boys",
+        "Beastie Boys"
+    ],
+    "The Beat Syndicate": [
+        "Beat Syndicate"
+    ],
+    "The Beatles": [
+        "Beatles"
+    ],
+    "The Beloved": [
+        "Beloved"
+    ],
+    "The Black Dog": [
+        "Black Dog"
+    ],
+    "The Black Eyed Peas": [
+        "Black Eyed Peas"
+    ],
+    "The Bloody Beetroots": [
+        "Bloody Beetroots"
+    ],
+    "The Brand New Heavies": [
+        "Brand New Heavies"
+    ],
+    "The Brookes Bros": [
+        "Brookes Bros"
+    ],
+    "The Brothers Grimm": [
+        "Brothers Grim",
+        "Brothers Grimm"
+    ],
+    "The Bucketheads": [
+        "Bucketheads"
+    ],
+    "The Buffalo Bunch": [
+        "The Buffallo Bunch"
+    ],
+    "The Buggles": [
+        "Buggles"
+    ],
+    "The Camel Riders": [
+        "Camel Riders",
+        "The Camel Rider"
+    ],
+    "The Chameleons": [
+        "The Chameleon",
+        "The Chamelion"
+    ],
+    "The Chemical Brothers": [
+        "''The Chemical Brothers",
+        "Chemical Brothers",
+        "Chemical Brothers, The",
+        "The Chemicial Brothers"
+    ],
+    "The Clash": [
+        "Clash"
+    ],
+    "The Coastal Commission": [
+        "The Costal Commission"
+    ],
+    "The Columbian Drum Cartel": [
+        "Columbian Drum Cartel"
+    ],
+    "The Committee": [
+        "Committee",
+        "The Committe"
+    ],
+    "The Conductor & The Cowboy": [
+        "Conductor & Cowboy",
+        "Conductor And The Cowboy"
+    ],
+    "The Cotton Club": [
+        "Cotton Club"
+    ],
+    "The Count & Sinden": [
+        "Count & Sinden",
+        "The Count And Sinden"
+    ],
+    "The Crystal Method": [
+        "Crystal Method"
+    ],
+    "The Cyclist": [
+        "Cyclist"
+    ],
+    "The Digital Blonde": [
+        "Digital Blonde",
+        "Digital Blondes"
+    ],
+    "The Disciples": [
+        "Disciples"
+    ],
+    "The Doors": [
+        "Doors"
+    ],
+    "The Doppler Effect": [
+        "Dooplereffect",
+        "Dopplereffekt"
+    ],
+    "The Dream Team": [
+        "Dreem Team",
+        "The Dreamteam"
+    ],
+    "The Electric Prunes": [
+        "Electric Prunes"
+    ],
+    "The Ethics": [
+        "Ethics",
+        "The Ethic"
+    ],
+    "The Experience": [
+        "Experience"
+    ],
+    "The Face": [
+        "Face"
+    ],
+    "The Fashion": [
+        "Fashion"
+    ],
+    "The Foot Club": [
+        "Footclub"
+    ],
+    "The Freestylers": [
+        "Freestylers"
+    ],
+    "The FunkJunkeez": [
+        "Funk Junkeez"
+    ],
+    "The Funky Lowlifes": [
+        "Funky Lowlifes",
+        "The Funky Lowlives"
+    ],
+    "The Funky People": [
+        "Funky People"
+    ],
+    "The Future Sound Of London": [
+        "F.S.O.L",
+        "F.S.O.L.",
+        "FSOL",
+        "Future Sound Of London"
+    ],
+    "The Gap Band": [
+        "Gapband"
+    ],
+    "The Golden Girls": [
+        "Golden Girls"
+    ],
+    "The Goodmen": [
+        "The Good Men"
+    ],
+    "The Gossip": [
+        "Gossip"
+    ],
+    "The Green Martian": [
+        "Green Martian"
+    ],
+    "The Groove Junkies": [
+        "Groove Junkies"
+    ],
+    "The Headhunters": [
+        "Headhunter",
+        "Headhunterz"
+    ],
+    "The Heartists": [
+        "The Heartist"
+    ],
+    "The Hed Boys": [
+        "Head Boys",
+        "Hed Boys"
+    ],
+    "The Hedge Trimmerz": [
+        "The Hedgetrimmerz"
+    ],
+    "The Heller & Farley Project": [
+        "Heller & Farley Project",
+        "Heller + Farley Project",
+        "The Heller N Farley Project"
+    ],
+    "The High Tech Child": [
+        "Hi Tech Child",
+        "Hi-Tech Child",
+        "The Hi Tech Child"
+    ],
+    "The Human League": [
+        "Human League"
+    ],
+    "The Incredible Bongo Band": [
+        "Incredible Bongo Band"
+    ],
+    "The Infernal Machine": [
+        "Infernal Machine"
+    ],
+    "The Infinity Project": [
+        "Infinity Project",
+        "The Infiniti Project"
+    ],
+    "The Invisible Man": [
+        "Invisible Man"
+    ],
+    "The Jackson 5": [
+        "Jackson 5"
+    ],
+    "The Japanese Popstars": [
+        "Japanease Popstars",
+        "Japanese Popstars"
+    ],
+    "The Jedi Knights": [
+        "Jedi Knights",
+        "Jedi Nights"
+    ],
+    "The Jets": [
+        "Jets"
+    ],
+    "The Jon Spencer Blues Explosion": [
+        "Jon Spencer Blues Explosion"
+    ],
+    "The Joubert Singers": [
+        "Joubert Singers"
+    ],
+    "The Juan MacLean": [
+        "Juan Maclean",
+        "The Juan Maclean",
+        "The Juan Mclean"
+    ],
+    "The KLF": [
+        "K.L.F",
+        "K.L.F.",
+        "KLF"
+    ],
+    "The Killers": [
+        "Killers"
+    ],
+    "The Klubb Kidz": [
+        "Klubb Kidz"
+    ],
+    "The Knowledge": [
+        "Knowledge",
+        "Knxwledge",
+        "The Knowedge"
+    ],
+    "The Knuckleheadz": [
+        "The Knucklehedz"
+    ],
+    "The Loops Of Fury": [
+        "Loops Of Fury"
+    ],
+    "The MD X-Press": [
+        "MD Express",
+        "MD X Spress",
+        "The MD X-Spress"
+    ],
+    "The Mambo Brothers": [
+        "Mambo Brothers"
+    ],
+    "The Martinez Brothers": [
+        "Martin Brothers",
+        "Martinez Brothers",
+        "The Martin Brothers"
+    ],
+    "The Martinez Brothers, Jerome Sydenham & Mathew Jonson": [
+        "The Martinez Brothers & Jerome Sydenham & Mathew Jonson"
+    ],
+    "The Martini Experience": [
+        "Montini Experience"
+    ],
+    "The Matrix": [
+        "Matrix"
+    ],
+    "The Micronauts": [
+        "Micronauts"
+    ],
+    "The Mole People": [
+        "Mole People"
+    ],
+    "The Mystic Moods": [
+        "Mystic Moods"
+    ],
+    "The Neanderthal": [
+        "Neanderthal"
+    ],
+    "The New Jersey Connection": [
+        "New Jersey Connection"
+    ],
+    "The Nextmen": [
+        "Nextmen"
+    ],
+    "The Nightcrawlers": [
+        "Nightcrawlers"
+    ],
+    "The Nightwriters": [
+        "Nightwriters"
+    ],
+    "The O'Jays": [
+        "The O'jays"
+    ],
+    "The Olmec Heads": [
+        "Olmec Heads"
+    ],
+    "The Orb": [
+        "Orb"
+    ],
+    "The Original Sins": [
+        "Original Sin"
+    ],
+    "The Paradise": [
+        "Paradise"
+    ],
+    "The Paragliders": [
+        "Paragliders"
+    ],
+    "The Parliaments": [
+        "Parliament"
+    ],
+    "The Partysquad": [
+        "Party Quad"
+    ],
+    "The Perfect Circle": [
+        "A Perfect Circle"
+    ],
+    "The Phantom": [
+        "Phantom"
+    ],
+    "The Pianoheadz": [
+        "Pianoheadz"
+    ],
+    "The Presets": [
+        "Presets"
+    ],
+    "The Prodigy": [
+        "Prodidgy",
+        "Prodigy"
+    ],
+    "The Prototypes": [
+        "Prototype"
+    ],
+    "The Psychonauts": [
+        "Psychonauts"
+    ],
+    "The Pump Panel": [
+        "Pump Panel"
+    ],
+    "The Quemists": [
+        "The Qemists"
+    ],
+    "The Reaver": [
+        "Reaver"
+    ],
+    "The Reese Project": [
+        "Reese Project"
+    ],
+    "The Rhythm Construction Co.": [
+        "Rhythm Construction Co."
+    ],
+    "The Rhythm Markers": [
+        "Rhythm Makers"
+    ],
+    "The Rhythm Masters": [
+        "Rhythm Masters",
+        "The Rythm Masters"
+    ],
+    "The Rolling Stones": [
+        "Rolling Stones"
+    ],
+    "The S Man": [
+        "S Man",
+        "The S\u2010Man"
+    ],
+    "The Salsoul Orchestra": [
+        "Salsoul Orchestra"
+    ],
+    "The Sandals": [
+        "The Sandels"
+    ],
+    "The Scumfrog": [
+        "Scumfrog",
+        "Scumfrogs",
+        "The Scum Frog"
+    ],
+    "The Sentinel": [
+        "The Sentinal"
+    ],
+    "The Shamen": [
+        "Shamen"
+    ],
+    "The Shapeshifters": [
+        "Shapeshifter",
+        "Shapeshifters"
+    ],
+    "The Sharp Boys": [
+        "Sharp Boys"
+    ],
+    "The Sneaker": [
+        "Sneaker"
+    ],
+    "The Soft Tigers": [
+        "Soft Tigers"
+    ],
+    "The Soul Searchers": [
+        "Soul Searcher",
+        "Soul Searchers",
+        "Soulsearcher"
+    ],
+    "The Source": [
+        "Source"
+    ],
+    "The Space Brothers": [
+        "Space Brothers"
+    ],
+    "The Stone Roses": [
+        "Stone Roses"
+    ],
+    "The Supermen Lovers": [
+        "Superman Lovers"
+    ],
+    "The Taste Experience": [
+        "Taste Experience",
+        "TasteXperience",
+        "Tastexperience"
+    ],
+    "The Thrillseekers": [
+        "Thrillseekers"
+    ],
+    "The Ting Tings": [
+        "Ting Tings"
+    ],
+    "The Trammps": [
+        "Trammps"
+    ],
+    "The Traveller": [
+        "Traveler"
+    ],
+    "The Tyrrel Corporation": [
+        "Tyrrel Corporation"
+    ],
+    "The Ultimate Seduction": [
+        "Ultimate Seduction"
+    ],
+    "The Usual Suspects": [
+        "Usual Suspects"
+    ],
+    "The Utopia Project": [
+        "Utopia Project"
+    ],
+    "The Vectif vs. The M. Experience": [
+        "The Vectif vs The M. Experience",
+        "The Vectif vs. The M Experience"
+    ],
+    "The White Stripes": [
+        "White Stripes",
+        "Whitestripes"
+    ],
+    "The Whitest Boy Alive": [
+        "Whitest Boy Alive"
+    ],
+    "The Wide Boys": [
+        "Wideboys"
+    ],
+    "The Wild Bunch": [
+        "Wild Bunch"
+    ],
+    "The Wiseguys": [
+        "Wiseguys"
+    ],
+    "The Woodshed": [
+        "Woodshed"
+    ],
+    "Thermobee & Stratosphere": [
+        "Thermobee & Statosphere"
+    ],
+    "Think Tank": [
+        "Think Tonk"
+    ],
+    "Thomas Anderson": [
+        "Tomas Anderson",
+        "Tomas Andersson"
+    ],
+    "Thomas Schumacher": [
+        "Thomas Schumaker"
+    ],
+    "Three Dee": [
+        "Three D"
+    ],
+    "Three N'One": [
+        "Three In One"
+    ],
+    "ThreeSixty & Dirty Harris": [
+        "Threesixty & Dirty Harris"
+    ],
+    "Tiefschwarz": [
+        "Tiefshwarz"
+    ],
+    "Tiga & Audion": [
+        "Tiga vs Audion"
+    ],
+    "Tiga & Zyntherius": [
+        "Tiga And Zyntherius"
+    ],
+    "Tilt & Paul Van Dyk": [
+        "Tilt & Paul van Dyk",
+        "Tilt And Paul van Dyk"
+    ],
+    "Timezone": [
+        "Time Zone"
+    ],
+    "Timmy & Tommy": [
+        "Timmy And Tommy"
+    ],
+    "Timo Maas": [
+        "Timo Mass"
+    ],
+    "Tinman": [
+        "Tin Man"
+    ],
+    "Ti\u00ebsto": [
+        "DJ Tiesto",
+        "DJ Ti\u00ebsto",
+        "Tiesto",
+        "Ti\u00ebsto"
+    ],
+    "Ti\u00ebsto & Hardwell": [
+        "Ti\u00ebsto vs Hardwell"
+    ],
+    "Tnght": [
+        "TNGHT"
+    ],
+    "Tobias": [
+        "Tobias."
+    ],
+    "Toddla T And Herv\u00e9": [
+        "Toddla T & Herve"
+    ],
+    "Tom Cole": [
+        "Tomcole"
+    ],
+    "Tom Middleton": [
+        "Tom Middelton"
+    ],
+    "Tom Stephane": [
+        "Tom Stephan"
+    ],
+    "Tomaz & Filterheadz": [
+        "Thomas vs Filterheadz",
+        "Tomas & Filterheads",
+        "Tomasz vs Filterheadz",
+        "Tomaz And Filterheadz",
+        "Tomaz vs Filterheadz"
+    ],
+    "Tombra Vira": [
+        "Tomba Vira"
+    ],
+    "Tommy Declerque": [
+        "Tomy Declerque"
+    ],
+    "Tommy Sunshine": [
+        "Tommie Sunshine"
+    ],
+    "Tonja Danzler": [
+        "Tonja Dantzler"
+    ],
+    "Tonja Holma": [
+        "ToNjA Holma"
+    ],
+    "Tony Rohr": [
+        "Toni Rohr"
+    ],
+    "Top Cat": [
+        "Top Kat",
+        "Topcat"
+    ],
+    "Total Science & S.P.Y.": [
+        "Total Science & S.P.Y"
+    ],
+    "Toulouse Low Trax": [
+        "Tolouse Low Trax"
+    ],
+    "Tracey Thorn": [
+        "Tracy Thorn"
+    ],
+    "Trackheadz": [
+        "Trackheads"
+    ],
+    "Traffic Signs": [
+        "Traffic Sign"
+    ],
+    "Trancesetters": [
+        "Trancetters"
+    ],
+    "Tranquility Bass": [
+        "Tranquility Base",
+        "Tranquillity Base"
+    ],
+    "Transatlantins": [
+        "The Transatlatins"
+    ],
+    "Transformer 2": [
+        "Transformer Z"
+    ],
+    "Transponder": [
+        "Trasponder"
+    ],
+    "Trax-X": [
+        "Traxx"
+    ],
+    "Traxman": [
+        "Trackmen",
+        "Traxmen"
+    ],
+    "Trentem\u00f8ller": [
+        "Trent Moller",
+        "Trentemoeller",
+        "Trentemoller",
+        "Trentem\u00f6ller",
+        "Trentmoller"
+    ],
+    "Trevor Rockliffe": [
+        "Trevor Rockcliffe"
+    ],
+    "Trey Max": [
+        "Ifrey Max"
+    ],
+    "Trolle & Siebenhaar": [
+        "Trolle Siebenhaar"
+    ],
+    "Trolley Snatcher": [
+        "Trolley Snatcha"
+    ],
+    "Twista": [
+        "Twister"
+    ],
+    "Twr72": [
+        "TWR72"
+    ],
+    "U.N.K.L.E.": [
+        "UNKLE",
+        "Unkle"
+    ],
+    "Ulterior Motive": [
+        "Ulterior Motives"
+    ],
+    "Ultra Nat\u00e9": [
+        "Ultra Nate"
+    ],
+    "Ultramagnetic MCs": [
+        "Ultramagnetic MC's"
+    ],
+    "Un-Cut": [
+        "Uncut"
+    ],
+    "Underground Sound Of Lisbon": [
+        "Underground Sounds Of Lisbon"
+    ],
+    "Underworld": [
+        "+ Underworld"
+    ],
+    "United Future Organisation": [
+        "U.F.O",
+        "U.F.O.",
+        "UFO",
+        "United Future Organization"
+    ],
+    "Unknown": [
+        "The Unknown",
+        "Unkown",
+        "[unknown]",
+        "unknown"
+    ],
+    "Unknown Artist": [
+        "Unknown Artist''"
+    ],
+    "Upgrade & TI": [
+        "UPGRADE & T>I"
+    ],
+    "Vainqueur": [
+        "Vainquer"
+    ],
+    "Valentino Kanzyani": [
+        "Valentine Kanzyani",
+        "Valentineo Kanzyani"
+    ],
+    "Vapourspace": [
+        "Vaporspace"
+    ],
+    "Vince Alley": [
+        "Vince Ailey"
+    ],
+    "Vincent De Moor": [
+        "Vincend De Moor"
+    ],
+    "Vinyl Groover & The Redhead": [
+        "Vinylgroover & Redhead",
+        "Vinylgroover & Redhed",
+        "Vinylgroover & The Red Hed"
+    ],
+    "Vitalic": [
+        "Fitalic"
+    ],
+    "Vu Du": [
+        "Vudu"
+    ],
+    "Waterm\u00e4t": [
+        "Watermat"
+    ],
+    "Westbam": [
+        "WestBam"
+    ],
+    "White Room": [
+        "Whiteroom"
+    ],
+    "White Rose Movement": [
+        "White Rose Mo Vement"
+    ],
+    "Who Made Who": [
+        "WhoMadeWho",
+        "Whomadewho"
+    ],
+    "Who's Who?": [
+        "Who's Who"
+    ],
+    "Wickaman": [
+        "Wickerman"
+    ],
+    "Wild Colour": [
+        "\"Wild Colour"
+    ],
+    "Wildlife!": [
+        "Wildlife"
+    ],
+    "Wojciech Kilar": [
+        "Woiciech Kilar"
+    ],
+    "Wolf 'N' Flow": [
+        "Huff N Flow",
+        "Wolf And Flow",
+        "Wolf N Flow",
+        "Wulf N Flow"
+    ],
+    "Woody van Eyden": [
+        "Wood Van Eyeden"
+    ],
+    "Workkidz": [
+        "Workidz"
+    ],
+    "Wreckx-N-Effect": [
+        "Wreckx N Effect"
+    ],
+    "X-102": [
+        "X102"
+    ],
+    "X-Cabs": [
+        "X Cabs"
+    ],
+    "X-Press 2": [
+        "X-Press-2",
+        "Xpress 2"
+    ],
+    "X-Project": [
+        "X Project"
+    ],
+    "X-Static": [
+        "X Static",
+        "Xstatic"
+    ],
+    "XGenic": [
+        "Xgenic"
+    ],
+    "Xample & Lomax": [
+        "Xample And Lomax"
+    ],
+    "Y-Traxx": [
+        "Y Trax",
+        "Y Traxx",
+        "Y'Traxx",
+        "Ytraxx"
+    ],
+    "Yeah Yeah Yeahs": [
+        "Yeahs Yeah Yeah"
+    ],
+    "Yolanda Be Cool & Dcup": [
+        "Yolanda Be Cool & DCUP"
+    ],
+    "Yves Deryuter": [
+        "Yves DeRuyter",
+        "Yves Deruytur"
+    ],
+    "Yvette Michelle": [
+        "Yvette Michele"
+    ],
+    "Zac Toms": [
+        "Zak Toms"
+    ],
+    "Zeb Roc Sci & Steber Twins": [
+        "Zeb Roc Ski & Steiber Twins"
+    ],
+    "Zeds Dead": [
+        "Zeds Deads"
+    ],
+    "Zeds Dead & Omar Linx": [
+        "Zeds Dead & Omar LinX"
+    ],
+    "Zen-Kei": [
+        "Zen Kei"
+    ],
+    "k.d. Lang": [
+        "KD Lang"
+    ],
+    "\u00c2me": [
+        "Ame"
+    ],
+    "\u00c9tienne Jaumet": [
+        "Etienne Jaumet"
+    ],
+    "\u00c9tienne de Cr\u00e9cy": [
+        "Etienne De Crecy",
+        "Etienne De Cr\u00e9cy",
+        "\u00c9tienne De Cr\u00e9cy"
+    ]
+}


### PR DESCRIPTION
This PR adds a JSON file that is a large `dict` of:

    '<artist's canonical name>': [List of alternate names / spellings]

e.g.

    "Afrika Bambattaa & Soul Sonic Force": [
        "Afrika Bambaataa & Soulsonic Force",
        "Afrika Bambaataa And The Soul Sonice Force",
        "Afrika Bambatta & The Soul Sonic Force"
    ],

This data was initially generated with [this code](https://gist.github.com/coverprice/1b2ba774d52976437afa338293239432) (with some minor modifications to improve matching, especially for artist names that contain the common words "A", "Vs", "And", & "The"). The data was then refined by hand to remove false positives and to choose canonical spellings. 

This PR also contains a small Python snippet that provides a method that, given an artist name extracted from `data.json`, it will return the artist's canonical name.

The intention is that this data/code can be used as part of a future effort to clean the raw `data.json` to ensure that each artist is represented by a single canonical name, so that statistics can be calculated more accurately. After this is done, it should also be possible to use "similar string" processing to create a list of canonical track names so that per-track statistics can also be more accurate.